### PR TITLE
[FEAT] 소셜 로그인 + JWT 엑세스, 리프레시 토큰 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,21 @@ dependencies {
 	implementation 'com.squareup.okhttp3:okhttp:4.10.0'
 	implementation 'com.slack.api:slack-app-backend:1.28.0'
 	implementation 'com.slack.api:slack-api-model:1.28.0'
+
+	// JWT
+	implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'
+	implementation group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
+	implementation group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.2'
+
+	// Spring Security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.security:spring-security-test'
+
+	// Redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+	// Social Login
+	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign:3.1.7'
 }
 
 tasks.named('test') {

--- a/src/main/java/sopt/org/umbbaServer/UmbbaServerApplication.java
+++ b/src/main/java/sopt/org/umbbaServer/UmbbaServerApplication.java
@@ -2,8 +2,13 @@ package sopt.org.umbbaServer;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@SpringBootApplication
+@EnableJpaAuditing
+@SpringBootApplication(exclude = { UserDetailsServiceAutoConfiguration.class })
+@EnableFeignClients
 public class UmbbaServerApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/sopt/org/umbbaServer/config/SecurityConfig.java
+++ b/src/main/java/sopt/org/umbbaServer/config/SecurityConfig.java
@@ -22,7 +22,7 @@ public class SecurityConfig {
     private final CustomJwtAuthenticationEntryPoint customJwtAuthenticationEntryPoint;
 
     private static final String[] AUTH_WHITELIST = {
-            "/kakao/**", "/login", "/refresh",
+            "/kakao/**", "/login", "/reissue",
 //          "/log-out",
             "/test"
     };

--- a/src/main/java/sopt/org/umbbaServer/config/SecurityConfig.java
+++ b/src/main/java/sopt/org/umbbaServer/config/SecurityConfig.java
@@ -1,0 +1,53 @@
+package sopt.org.umbbaServer.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import sopt.org.umbbaServer.domain.user.jwt.security.CustomJwtAuthenticationEntryPoint;
+import sopt.org.umbbaServer.domain.user.jwt.security.JwtAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final CustomJwtAuthenticationEntryPoint customJwtAuthenticationEntryPoint;
+
+    private static final String[] AUTH_WHITELIST = {
+            "/kakao/**", "/login", "/refresh",
+//          "/log-out",
+            "/test"
+    };
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        return http
+                .formLogin().disable() // Form Login 사용 X
+                .httpBasic().disable() // HTTP Basic 사용 X
+                .csrf().disable() // 쿠키 기반이 아닌 JWT 기반이므로 사용 X
+                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS) // Spring Security 세션 정책 : 세션을 생성 및 사용하지 않음
+                .and()
+                .exceptionHandling()
+                .authenticationEntryPoint(customJwtAuthenticationEntryPoint) // 에러 핸들링
+                .and()
+                .authorizeHttpRequests()
+                .antMatchers(AUTH_WHITELIST).permitAll()
+                .anyRequest().authenticated()
+                .and()
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class) // JWT 인증 필터 적용
+                .build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+    }
+}

--- a/src/main/java/sopt/org/umbbaServer/domain/user/controller/AuthController.java
+++ b/src/main/java/sopt/org/umbbaServer/domain/user/controller/AuthController.java
@@ -1,0 +1,61 @@
+package sopt.org.umbbaServer.domain.user.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import sopt.org.umbbaServer.domain.user.dto.RefreshRequestDto;
+import sopt.org.umbbaServer.domain.user.dto.SocialLoginRequestDto;
+import sopt.org.umbbaServer.domain.user.dto.UserLoginResponseDto;
+import sopt.org.umbbaServer.domain.user.jwt.JwtProvider;
+import sopt.org.umbbaServer.domain.user.jwt.TokenDto;
+import sopt.org.umbbaServer.domain.user.service.AuthService;
+import sopt.org.umbbaServer.domain.user.social.kakao.KakaoLoginService;
+import sopt.org.umbbaServer.error.ApiResponse;
+import sopt.org.umbbaServer.error.SuccessType;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.Principal;
+import java.security.spec.InvalidKeySpecException;
+
+@RestController
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+    private final KakaoLoginService kakaoLoginService;
+
+    @PostMapping("/login")
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResponse<UserLoginResponseDto> login(
+            @RequestHeader("Authorization") String socialAccessToken,
+            @RequestBody SocialLoginRequestDto request) throws NoSuchAlgorithmException, InvalidKeySpecException {
+
+        UserLoginResponseDto response = authService.login(socialAccessToken, request);
+        return ApiResponse.success(SuccessType.LOGIN_SUCCESS, response);
+    }
+
+    @PostMapping("/refresh")
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResponse<TokenDto> refresh(
+            @RequestHeader("Authorization") String refreshToken,
+            @RequestBody RefreshRequestDto request) throws Exception {
+
+        return ApiResponse.success(SuccessType.REFRESH_SUCCESS, authService.refreshToken(request.getUserId(), refreshToken));
+    }
+
+    @PostMapping("/log-out") // Spring Security 자체 로그아웃과 충돌하기 때문에 이렇게 써줌
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResponse logout(Principal principal) {
+
+        authService.logout(JwtProvider.getUserFromPrincial(principal));
+        return ApiResponse.success(SuccessType.LOGOUT_SUCCESS);
+    }
+
+    @PostMapping("/kakao")
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResponse kakaoAccessToken(
+            @RequestHeader("Authorization") String code) {
+
+        return ApiResponse.success(SuccessType.KAKAO_ACCESS_TOKEN_SUCCESS, kakaoLoginService.getKakaoAccessToken(code));
+    }
+}

--- a/src/main/java/sopt/org/umbbaServer/domain/user/controller/AuthController.java
+++ b/src/main/java/sopt/org/umbbaServer/domain/user/controller/AuthController.java
@@ -34,13 +34,13 @@ public class AuthController {
         return ApiResponse.success(SuccessType.LOGIN_SUCCESS, response);
     }
 
-    @PostMapping("/refresh")
+    @PostMapping("/reissue")
     @ResponseStatus(HttpStatus.OK)
-    public ApiResponse<TokenDto> refresh(
+    public ApiResponse<TokenDto> reissue(
             @RequestHeader("Authorization") String refreshToken,
             @RequestBody RefreshRequestDto request) throws Exception {
 
-        return ApiResponse.success(SuccessType.REFRESH_SUCCESS, authService.refreshToken(request.getUserId(), refreshToken));
+        return ApiResponse.success(SuccessType.REISSUE_SUCCESS, authService.reissueToken(request.getUserId(), refreshToken));
     }
 
     @PostMapping("/log-out") // Spring Security 자체 로그아웃과 충돌하기 때문에 이렇게 써줌

--- a/src/main/java/sopt/org/umbbaServer/domain/user/dto/RefreshRequestDto.java
+++ b/src/main/java/sopt/org/umbbaServer/domain/user/dto/RefreshRequestDto.java
@@ -1,0 +1,12 @@
+package sopt.org.umbbaServer.domain.user.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class RefreshRequestDto {
+
+    private Long userId;
+}

--- a/src/main/java/sopt/org/umbbaServer/domain/user/dto/SocialLoginRequestDto.java
+++ b/src/main/java/sopt/org/umbbaServer/domain/user/dto/SocialLoginRequestDto.java
@@ -1,0 +1,13 @@
+package sopt.org.umbbaServer.domain.user.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import sopt.org.umbbaServer.domain.user.social.SocialPlatform;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class SocialLoginRequestDto {
+
+    private SocialPlatform socialPlatform;
+}

--- a/src/main/java/sopt/org/umbbaServer/domain/user/dto/UserLoginResponseDto.java
+++ b/src/main/java/sopt/org/umbbaServer/domain/user/dto/UserLoginResponseDto.java
@@ -1,0 +1,45 @@
+package sopt.org.umbbaServer.domain.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import sopt.org.umbbaServer.domain.user.jwt.TokenDto;
+import sopt.org.umbbaServer.domain.user.model.User;
+import sopt.org.umbbaServer.domain.user.social.SocialPlatform;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserLoginResponseDto {
+    private Long userId;
+
+    private String username;
+
+    private String gender;
+
+    private Integer bornYear;
+
+    private TokenDto tokenDto;
+
+    private SocialPlatform socialPlatform;
+
+    private String socialNickname;
+
+    private String socialProfileImage;
+
+    private String socialAccessToken;
+
+//    private String socialRefreshToken;
+
+    public static UserLoginResponseDto of(User loginUser, String accessToken) {
+        TokenDto tokenDto = TokenDto.of(accessToken, loginUser.getRefreshToken());
+
+        return new UserLoginResponseDto(
+                loginUser.getId(), loginUser.getUsername(), loginUser.getGender(), loginUser.getBornYear(),
+                tokenDto,
+                loginUser.getSocialPlatform(), loginUser.getSocialNickname(), loginUser.getSocialProfileImage(),
+                loginUser.getSocialAccessToken()/*, loginUser.getSocialRefreshToken()*/);
+    }
+}

--- a/src/main/java/sopt/org/umbbaServer/domain/user/jwt/JwtProvider.java
+++ b/src/main/java/sopt/org/umbbaServer/domain/user/jwt/JwtProvider.java
@@ -1,0 +1,131 @@
+package sopt.org.umbbaServer.domain.user.jwt;
+
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+import sopt.org.umbbaServer.domain.user.jwt.redis.RefreshToken;
+import sopt.org.umbbaServer.domain.user.jwt.redis.TokenRepository;
+import sopt.org.umbbaServer.error.CustomException;
+import sopt.org.umbbaServer.error.ErrorType;
+
+import javax.annotation.PostConstruct;
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.security.Principal;
+import java.util.Base64;
+import java.util.Date;
+import java.util.UUID;
+
+import static java.util.Objects.isNull;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtProvider {
+
+    @Value("${jwt.secret}")
+    private String JWT_SECRET;
+    private final TokenRepository tokenRepository;
+
+    @PostConstruct
+    protected void init() {
+        JWT_SECRET = Base64.getEncoder().encodeToString(JWT_SECRET.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public String generateAccessToken(Authentication authentication, Long tokenExpirationTime) {
+        final Date now = new Date();
+
+        final Claims claims = Jwts.claims()
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + tokenExpirationTime));
+
+        claims.put("userId", authentication.getPrincipal());
+
+        return Jwts.builder()
+                .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+                .setClaims(claims)
+                .signWith(getSigningKey())
+                .compact();
+    }
+
+    // Refresh 토큰 생성
+    /**
+     * Redis 내부에는
+     * refreshToken:userId : tokenValue 형태로 저장한다.
+     * accessToken과 다르게 UUID로 생성한다.
+     */
+    public String generateRefreshToken(Authentication authentication, Long tokenExpirationTime) {
+
+        RefreshToken refreshToken = tokenRepository.save(
+                RefreshToken.builder()
+                        .id(Long.parseLong(authentication.getPrincipal().toString()))
+                        .refreshToken(UUID.randomUUID().toString())
+                        .expiration(tokenExpirationTime.intValue() / 1000)
+                        .build()
+        );
+        return refreshToken.getRefreshToken();
+    }
+
+    // Access 토큰 검증
+    public JwtValidationType validateAccessToken(String accessToken) {
+        try {
+            final Claims claims = getBody(accessToken);
+            return JwtValidationType.VALID_JWT;
+        } catch (MalformedJwtException ex) {
+            log.error(String.valueOf(JwtValidationType.INVALID_JWT_TOKEN));
+            return JwtValidationType.INVALID_JWT_TOKEN;
+        } catch (ExpiredJwtException ex) {
+            log.error(String.valueOf(JwtValidationType.EXPIRED_JWT_TOKEN));
+            return JwtValidationType.EXPIRED_JWT_TOKEN;
+        } catch (UnsupportedJwtException ex) {
+            log.error(String.valueOf(JwtValidationType.UNSUPPORTED_JWT_TOKEN));
+            return JwtValidationType.UNSUPPORTED_JWT_TOKEN;
+        } catch (IllegalArgumentException ex) {
+            log.error(String.valueOf(JwtValidationType.EMPTY_JWT));
+            return JwtValidationType.EMPTY_JWT;
+        }
+    }
+
+    // Refresh 토큰 검증
+    public boolean validRefreshToken(Long userId, String refreshToken) throws Exception {
+        // 해당유저의 Refresh 토큰 만료 : Redis에 해당 유저의 토큰이 존재하지 않음
+        RefreshToken token = tokenRepository.findById(userId).orElseThrow(() -> new CustomException(ErrorType.INVALID_REFRESH_TOKEN));
+
+        if (token.getRefreshToken() == null) {
+            return false;
+        }
+        else return token.getRefreshToken().equals(refreshToken);
+    }
+
+    // 토큰에 담겨있는 userId 획득
+    public Long getUserFromJwt(String token) {
+        Claims claims = getBody(token);
+        return Long.parseLong(claims.get("userId").toString());
+    }
+
+    private Claims getBody(final String token) {
+        // 만료된 토큰에 대해 parseClaimsJws를 수행하면 io.jsonwebtoken.ExpiredJwtException이 발생한다.
+        return Jwts.parserBuilder()
+                .setSigningKey(getSigningKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+    private SecretKey getSigningKey() {
+        String encodedKey = Base64.getEncoder().encodeToString(JWT_SECRET.getBytes());
+        return Keys.hmacShaKeyFor(encodedKey.getBytes());
+    }
+
+    public static Long getUserFromPrincial(Principal principal) {
+        if (isNull(principal)) {
+            throw new CustomException(ErrorType.EMPTY_PRINCIPLE_EXCEPTION);
+        }
+        return Long.valueOf(principal.getName());
+    }
+}

--- a/src/main/java/sopt/org/umbbaServer/domain/user/jwt/JwtValidationType.java
+++ b/src/main/java/sopt/org/umbbaServer/domain/user/jwt/JwtValidationType.java
@@ -1,0 +1,10 @@
+package sopt.org.umbbaServer.domain.user.jwt;
+
+public enum JwtValidationType {
+    VALID_JWT,
+    INVALID_JWT_SIGNATURE,
+    INVALID_JWT_TOKEN,
+    EXPIRED_JWT_TOKEN,
+    UNSUPPORTED_JWT_TOKEN,
+    EMPTY_JWT
+}

--- a/src/main/java/sopt/org/umbbaServer/domain/user/jwt/TokenDto.java
+++ b/src/main/java/sopt/org/umbbaServer/domain/user/jwt/TokenDto.java
@@ -1,0 +1,18 @@
+package sopt.org.umbbaServer.domain.user.jwt;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class TokenDto {
+
+    private String accessToken;
+    private String refreshToken;
+
+    public static TokenDto of(String accessToken, String refreshToken) {
+        return new TokenDto(accessToken, refreshToken);
+    }
+}

--- a/src/main/java/sopt/org/umbbaServer/domain/user/jwt/redis/RefreshToken.java
+++ b/src/main/java/sopt/org/umbbaServer/domain/user/jwt/redis/RefreshToken.java
@@ -1,0 +1,29 @@
+package sopt.org.umbbaServer.domain.user.jwt.redis;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+
+import javax.persistence.Id;
+import java.util.concurrent.TimeUnit;
+
+@Getter
+@RedisHash("refreshToken")
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class RefreshToken {
+
+    @Id
+    @JsonIgnore
+    private Long id;
+
+    private String refreshToken;
+
+    @TimeToLive(unit = TimeUnit.SECONDS)
+    private Integer expiration;
+}

--- a/src/main/java/sopt/org/umbbaServer/domain/user/jwt/redis/TokenRepository.java
+++ b/src/main/java/sopt/org/umbbaServer/domain/user/jwt/redis/TokenRepository.java
@@ -1,0 +1,7 @@
+package sopt.org.umbbaServer.domain.user.jwt.redis;
+
+import org.springframework.data.repository.CrudRepository;
+
+//Redis에 저장해주는 역할
+public interface TokenRepository extends CrudRepository<RefreshToken, Long> {
+}

--- a/src/main/java/sopt/org/umbbaServer/domain/user/jwt/security/CustomJwtAuthenticationEntryPoint.java
+++ b/src/main/java/sopt/org/umbbaServer/domain/user/jwt/security/CustomJwtAuthenticationEntryPoint.java
@@ -1,0 +1,30 @@
+package sopt.org.umbbaServer.domain.user.jwt.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+import sopt.org.umbbaServer.error.ApiResponse;
+import sopt.org.umbbaServer.error.ErrorType;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+public class CustomJwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
+      setResponse(response);
+    }
+
+    private void setResponse(HttpServletResponse response) throws IOException {
+        response.setCharacterEncoding("UTF-8");
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.getWriter().println(objectMapper.writeValueAsString(ApiResponse.error(ErrorType.INVALID_ACCESS_TOKEN)));
+    }
+}

--- a/src/main/java/sopt/org/umbbaServer/domain/user/jwt/security/JwtAuthenticationFilter.java
+++ b/src/main/java/sopt/org/umbbaServer/domain/user/jwt/security/JwtAuthenticationFilter.java
@@ -1,0 +1,58 @@
+package sopt.org.umbbaServer.domain.user.jwt.security;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+import sopt.org.umbbaServer.domain.user.jwt.JwtProvider;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+import static sopt.org.umbbaServer.domain.user.jwt.JwtValidationType.VALID_JWT;
+
+/**
+ * JWT가 유효성을 검증하는 Filter
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtProvider jwtProvider;
+
+    @Override
+    protected void doFilterInternal(@NonNull HttpServletRequest request, @NonNull HttpServletResponse response, @NonNull FilterChain filterChain) throws IOException, ServletException {
+        try {
+
+            // Request의 Header에서 JWT 토큰을 String으로 가져옴
+            final String token = getJwtFromRequest(request);
+
+            if (StringUtils.hasText(token) && jwtProvider.validateAccessToken(token) == VALID_JWT) {
+                Long userId = jwtProvider.getUserFromJwt(token);
+                UserAuthentication authentication = new UserAuthentication(userId, null, null);
+                authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+        } catch (Exception exception) {
+            log.error("error : ", exception);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String getJwtFromRequest(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring("Bearer ".length());
+        }
+        return null;
+    }
+}

--- a/src/main/java/sopt/org/umbbaServer/domain/user/jwt/security/UserAuthentication.java
+++ b/src/main/java/sopt/org/umbbaServer/domain/user/jwt/security/UserAuthentication.java
@@ -1,0 +1,15 @@
+package sopt.org.umbbaServer.domain.user.jwt.security;
+
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.Collection;
+
+public class UserAuthentication extends UsernamePasswordAuthenticationToken {
+
+    public UserAuthentication(Object principal, Object credentials, Collection<? extends GrantedAuthority> authorities) {
+        super(principal, credentials, authorities);
+
+    }
+}

--- a/src/main/java/sopt/org/umbbaServer/domain/user/model/User.java
+++ b/src/main/java/sopt/org/umbbaServer/domain/user/model/User.java
@@ -1,0 +1,63 @@
+package sopt.org.umbbaServer.domain.user.model;
+
+import lombok.*;
+import sopt.org.umbbaServer.domain.user.social.SocialPlatform;
+import sopt.org.umbbaServer.util.AuditingTimeEntity;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class User extends AuditingTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+//    @Column(nullable = false) // 사실 온보딩 단계에서 입력되기 때문에 nullable = true로 가져가야함
+    private String username;
+
+//    @Column(nullable = false)
+    private String gender;
+
+//    @Column(nullable = false)
+    private Integer bornYear;
+
+    private String refreshToken;
+
+    public void updateRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+
+    // ** 소셜 로그인 관련 **
+    @Enumerated(EnumType.STRING)
+    private SocialPlatform socialPlatform;
+
+    @Column(nullable = false) // 이걸 PK로 가져갈지 고민
+    private String socialId;
+
+    private String socialNickname;
+
+    private String socialProfileImage;
+
+    private String socialAccessToken;
+
+//    private String socialRefreshToken;
+    //
+
+    // 로그인 새롭게 할 때마다 해당 필드들 업데이트
+    public void updateSocialInfo(String socialNickname, String socialProfileImage, String socialAccessToken/*, String socialRefreshToken*/) {
+        this.socialNickname = socialNickname;
+        this.socialProfileImage = socialProfileImage;
+        this.socialAccessToken = socialAccessToken;
+//        this.socialRefreshToken = socialRefreshToken;
+    }
+
+    public User(SocialPlatform socialPlatform, String socialId) {
+        this.socialPlatform = socialPlatform;
+        this.socialId = socialId;
+    }
+}

--- a/src/main/java/sopt/org/umbbaServer/domain/user/repository/UserRepository.java
+++ b/src/main/java/sopt/org/umbbaServer/domain/user/repository/UserRepository.java
@@ -1,0 +1,22 @@
+package sopt.org.umbbaServer.domain.user.repository;
+
+import org.springframework.data.repository.Repository;
+import sopt.org.umbbaServer.domain.user.model.User;
+import sopt.org.umbbaServer.domain.user.social.SocialPlatform;
+
+import java.util.Optional;
+
+public interface UserRepository extends Repository<User, Long> {
+
+    // CREATE
+    void save(User user);
+
+    // READ
+    Optional<User> findById(Long id);
+    boolean existsBySocialPlatformAndSocialId(SocialPlatform socialPlatform, String socialId);
+    Optional<User> findBySocialPlatformAndSocialId(SocialPlatform socialPlatform, String socialId);
+
+    // UPDATE
+
+    // DELETE
+}

--- a/src/main/java/sopt/org/umbbaServer/domain/user/service/AuthService.java
+++ b/src/main/java/sopt/org/umbbaServer/domain/user/service/AuthService.java
@@ -1,0 +1,122 @@
+package sopt.org.umbbaServer.domain.user.service;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import sopt.org.umbbaServer.domain.user.dto.SocialLoginRequestDto;
+import sopt.org.umbbaServer.domain.user.dto.UserLoginResponseDto;
+import sopt.org.umbbaServer.domain.user.jwt.JwtProvider;
+import sopt.org.umbbaServer.domain.user.jwt.TokenDto;
+import sopt.org.umbbaServer.domain.user.jwt.redis.TokenRepository;
+import sopt.org.umbbaServer.domain.user.jwt.security.UserAuthentication;
+import sopt.org.umbbaServer.domain.user.model.User;
+import sopt.org.umbbaServer.domain.user.repository.UserRepository;
+import sopt.org.umbbaServer.domain.user.social.SocialPlatform;
+import sopt.org.umbbaServer.domain.user.social.apple.AppleLoginService;
+import sopt.org.umbbaServer.domain.user.social.kakao.KakaoLoginService;
+import sopt.org.umbbaServer.error.CustomException;
+import sopt.org.umbbaServer.error.ErrorType;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AuthService { 
+    
+    private static final Long ACCESS_TOKEN_EXPIRATION_TIME = 60 * 1000L;  // 액세스 토큰 만료 시간: 1분으로 지정
+
+    private static final Long REFRESH_TOKEN_EXPIRATION_TIME = 60 * 1000L * 2;  // 리프레시 토큰 만료 시간: 2분으로 지정
+
+    private final JwtProvider jwtProvider;
+    private final UserRepository userRepository;
+    private final TokenRepository tokenRepository;
+
+    private final AppleLoginService appleLoginService;
+    private final KakaoLoginService kakaoLoginService;
+
+    @Transactional
+    public UserLoginResponseDto login(String socialAccessToken, SocialLoginRequestDto request) throws NoSuchAlgorithmException, InvalidKeySpecException {
+
+        SocialPlatform socialPlatform = request.getSocialPlatform();
+        String socialId = login(request.getSocialPlatform(), socialAccessToken);
+
+        boolean isRegistered = isUserBySocialAndSocialId(socialPlatform, socialId);
+
+        if (!isRegistered) {
+
+            User user = User.builder()
+                    .socialPlatform(socialPlatform)
+                    .socialId(socialId).build();
+
+            userRepository.save(user);
+        }
+
+        User loginUser = getUserBySocialAndSocialId(socialPlatform, socialId);
+
+        // 카카오는 정보 더 많이 받아올 수 있으므로 추가 설정
+        if (socialPlatform == SocialPlatform.KAKAO) {
+            kakaoLoginService.setKakaoInfo(loginUser, socialAccessToken);
+        }
+
+        TokenDto tokenDto = generateToken(new UserAuthentication(loginUser.getId(), null, null));
+        loginUser.updateRefreshToken(tokenDto.getRefreshToken());
+
+        return UserLoginResponseDto.of(loginUser, tokenDto.getAccessToken());
+    }
+
+    @Transactional
+    public TokenDto refreshToken(Long userId, String refreshToken) throws Exception {
+
+        User user = getUserById(userId); //userId가 잘못 날라오는 경우에 대비해 남김
+
+        if (jwtProvider.validRefreshToken(userId, refreshToken)) {
+            return generateToken(new UserAuthentication(userId, null, null));
+
+        } else {
+            throw new CustomException(ErrorType.NOTMATCH_REFRESH_TOKEN);
+        }
+    }
+
+    @Transactional
+    public void logout(Long userId) {
+        User user = getUserById(userId);
+        user.updateRefreshToken(null);
+        tokenRepository.deleteById(userId);
+    }
+
+    private TokenDto generateToken(Authentication authentication) {
+        return TokenDto.of(
+                jwtProvider.generateAccessToken(authentication, ACCESS_TOKEN_EXPIRATION_TIME),
+                jwtProvider.generateRefreshToken(authentication, REFRESH_TOKEN_EXPIRATION_TIME));
+    }
+
+    private User getUserById(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorType.INVALID_USER));
+    }
+
+    private User getUserBySocialAndSocialId(SocialPlatform socialPlatform, String socialId) {
+        return userRepository.findBySocialPlatformAndSocialId(socialPlatform, socialId)
+                .orElseThrow(() -> new CustomException(ErrorType.INVALID_USER));
+    }
+
+    private boolean isUserBySocialAndSocialId(SocialPlatform socialPlatform, String socialId) {
+        return userRepository.existsBySocialPlatformAndSocialId(socialPlatform, socialId);
+    }
+
+    private String login(SocialPlatform socialPlatform, String socialAccessToken) throws NoSuchAlgorithmException, InvalidKeySpecException {
+        switch (socialPlatform.toString()) {
+            case "APPLE":
+                return appleLoginService.getAppleId(socialAccessToken);
+            case "KAKAO":
+                return kakaoLoginService.getKakaoId(socialAccessToken);
+            default:
+                throw new CustomException(ErrorType.INVALID_SOCIAL_ACCESS_TOKEN);
+        }
+
+    }
+}

--- a/src/main/java/sopt/org/umbbaServer/domain/user/service/AuthService.java
+++ b/src/main/java/sopt/org/umbbaServer/domain/user/service/AuthService.java
@@ -26,14 +26,9 @@ import java.security.spec.InvalidKeySpecException;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class AuthService { 
-    
-    private static final Long ACCESS_TOKEN_EXPIRATION_TIME = 60 * 1000L;  // 액세스 토큰 만료 시간: 1분으로 지정
-
-    private static final Long REFRESH_TOKEN_EXPIRATION_TIME = 60 * 1000L * 2;  // 리프레시 토큰 만료 시간: 2분으로 지정
 
     private final JwtProvider jwtProvider;
     private final UserRepository userRepository;
-    private final TokenRepository tokenRepository;
 
     private final AppleLoginService appleLoginService;
     private final KakaoLoginService kakaoLoginService;
@@ -69,7 +64,7 @@ public class AuthService {
     }
 
     @Transactional
-    public TokenDto refreshToken(Long userId, String refreshToken) throws Exception {
+    public TokenDto reissueToken(Long userId, String refreshToken) throws Exception {
 
         User user = getUserById(userId); //userId가 잘못 날라오는 경우에 대비해 남김
 
@@ -85,13 +80,13 @@ public class AuthService {
     public void logout(Long userId) {
         User user = getUserById(userId);
         user.updateRefreshToken(null);
-        tokenRepository.deleteById(userId);
+        jwtProvider.deleteRefreshToken(userId);
     }
 
     private TokenDto generateToken(Authentication authentication) {
         return TokenDto.of(
-                jwtProvider.generateAccessToken(authentication, ACCESS_TOKEN_EXPIRATION_TIME),
-                jwtProvider.generateRefreshToken(authentication, REFRESH_TOKEN_EXPIRATION_TIME));
+                jwtProvider.generateAccessToken(authentication),
+                jwtProvider.generateRefreshToken(authentication));
     }
 
     private User getUserById(Long userId) {

--- a/src/main/java/sopt/org/umbbaServer/domain/user/social/SocialPlatform.java
+++ b/src/main/java/sopt/org/umbbaServer/domain/user/social/SocialPlatform.java
@@ -1,0 +1,15 @@
+package sopt.org.umbbaServer.domain.user.social;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum SocialPlatform {
+    KAKAO("카카오"),
+    APPLE("애플")
+    ;
+
+    private final String value;
+}

--- a/src/main/java/sopt/org/umbbaServer/domain/user/social/apple/AppleLoginService.java
+++ b/src/main/java/sopt/org/umbbaServer/domain/user/social/apple/AppleLoginService.java
@@ -1,0 +1,43 @@
+package sopt.org.umbbaServer.domain.user.social.apple;
+
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import sopt.org.umbbaServer.domain.user.social.apple.feign.AppleApiClient;
+import sopt.org.umbbaServer.domain.user.social.apple.response.ApplePublicKeys;
+import sopt.org.umbbaServer.domain.user.social.apple.verify.AppleClaimsValidator;
+import sopt.org.umbbaServer.domain.user.social.apple.verify.AppleJwtParser;
+import sopt.org.umbbaServer.domain.user.social.apple.verify.PublicKeyGenerator;
+import sopt.org.umbbaServer.error.CustomException;
+import sopt.org.umbbaServer.error.ErrorType;
+
+import java.security.PublicKey;
+import java.util.Map;
+
+@RequiredArgsConstructor
+@Service
+public class AppleLoginService {
+
+    private final AppleApiClient appleApiClient;
+    private final AppleJwtParser appleJwtParser;
+    private final PublicKeyGenerator publicKeyGenerator;
+    private final AppleClaimsValidator appleClaimsValidator;
+
+    public String getAppleId(String identityToken) {
+        Map<String, String> headers = appleJwtParser.parseHeaders(identityToken);
+        ApplePublicKeys applePublicKeys = appleApiClient.getApplePublicKeys();
+
+        PublicKey publicKey = publicKeyGenerator.generatePublicKey(headers, applePublicKeys);
+
+        Claims claims = appleJwtParser.parsePublicKeyAndGetClaims(identityToken, publicKey);
+        validateClaims(claims);
+        return claims.getSubject();
+    }
+
+    private void validateClaims(Claims claims) {
+        if (!appleClaimsValidator.isValid(claims)) {
+            throw new CustomException(ErrorType.INVALID_APPLE_CLAIMS);
+        }
+    }
+
+}

--- a/src/main/java/sopt/org/umbbaServer/domain/user/social/apple/feign/AppleApiClient.java
+++ b/src/main/java/sopt/org/umbbaServer/domain/user/social/apple/feign/AppleApiClient.java
@@ -1,0 +1,12 @@
+package sopt.org.umbbaServer.domain.user.social.apple.feign;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import sopt.org.umbbaServer.domain.user.social.apple.response.ApplePublicKeys;
+
+@FeignClient(name = "apple-public-verify-client", url = "https://appleid.apple.com/auth")
+public interface AppleApiClient {
+
+    @GetMapping("/keys")
+    ApplePublicKeys getApplePublicKeys();
+}

--- a/src/main/java/sopt/org/umbbaServer/domain/user/social/apple/response/ApplePublicKey.java
+++ b/src/main/java/sopt/org/umbbaServer/domain/user/social/apple/response/ApplePublicKey.java
@@ -1,0 +1,20 @@
+package sopt.org.umbbaServer.domain.user.social.apple.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+public class ApplePublicKey {
+
+    private String kty;
+    private String kid;
+    private String use;
+    private String alg;
+    private String n;
+    private String e;
+}
+

--- a/src/main/java/sopt/org/umbbaServer/domain/user/social/apple/response/ApplePublicKeys.java
+++ b/src/main/java/sopt/org/umbbaServer/domain/user/social/apple/response/ApplePublicKeys.java
@@ -1,0 +1,27 @@
+package sopt.org.umbbaServer.domain.user.social.apple.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import sopt.org.umbbaServer.error.CustomException;
+import sopt.org.umbbaServer.error.ErrorType;
+
+import java.util.List;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+public class ApplePublicKeys {
+
+    private List<ApplePublicKey> keys;
+
+    public ApplePublicKey getMatchesKey(String alg, String kid) {
+        return this.keys
+                .stream()
+                .filter(k -> k.getAlg().equals(alg) && k.getKid().equals(kid))
+                .findFirst()
+                .orElseThrow(() -> new CustomException(ErrorType.INVALID_APPLE_PUBLIC_KEY));
+    }
+
+}

--- a/src/main/java/sopt/org/umbbaServer/domain/user/social/apple/verify/AppleClaimsValidator.java
+++ b/src/main/java/sopt/org/umbbaServer/domain/user/social/apple/verify/AppleClaimsValidator.java
@@ -1,0 +1,32 @@
+package sopt.org.umbbaServer.domain.user.social.apple.verify;
+
+import io.jsonwebtoken.Claims;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AppleClaimsValidator {
+
+    private static final String NONCE_KEY = "nonce";
+
+    private final String iss;
+    private final String clientId;
+    private final String nonce; // iOS 멘토링에서 질문 후 사용 여부 결정
+
+    public AppleClaimsValidator(
+            @Value("${apple.iss}") String iss,
+            @Value("${apple.client-id}") String clientId,
+            @Value("${apple.nonce}") String nonce
+    ) {
+        this.iss = iss;
+        this.clientId = clientId;
+        this.nonce = EncryptUtils.encrypt(nonce);
+    }
+
+    public boolean isValid(Claims claims) {
+        return claims.getIssuer().contains(iss)
+                && claims.getAudience().equals(clientId);
+//                && claims.get(NONCE_KEY, String.class).equals(nonce);
+    }
+}
+

--- a/src/main/java/sopt/org/umbbaServer/domain/user/social/apple/verify/AppleJwtParser.java
+++ b/src/main/java/sopt/org/umbbaServer/domain/user/social/apple/verify/AppleJwtParser.java
@@ -1,0 +1,47 @@
+package sopt.org.umbbaServer.domain.user.social.apple.verify;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.*;
+import org.springframework.stereotype.Component;
+import org.springframework.util.Base64Utils;
+import sopt.org.umbbaServer.error.CustomException;
+import sopt.org.umbbaServer.error.ErrorType;
+
+import java.security.PublicKey;
+import java.util.Map;
+
+@Component
+public class AppleJwtParser {
+
+    private static final String IDENTITY_TOKEN_VALUE_DELIMITER = "\\.";
+    private static final int HEADER_INDEX = 0;
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    public Map<String, String> parseHeaders(String identityToken) {
+        try {
+            String encodedHeader = identityToken.split(IDENTITY_TOKEN_VALUE_DELIMITER)[HEADER_INDEX];
+            String decodedHeader = new String(Base64Utils.decodeFromUrlSafeString(encodedHeader));
+            return OBJECT_MAPPER.readValue(decodedHeader, Map.class);
+
+        } catch (JsonProcessingException | ArrayIndexOutOfBoundsException e) {
+            throw new CustomException(ErrorType.INVALID_APPLE_IDENTITY_TOKEN);
+        }
+    }
+
+    public Claims parsePublicKeyAndGetClaims(String idToken, PublicKey publicKey) {
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(publicKey)
+                    .build()
+                    .parseClaimsJws(idToken)
+                    .getBody();
+
+        } catch (ExpiredJwtException e) {
+            throw new CustomException(ErrorType.EXPIRED_APPLE_IDENTITY_TOKEN);
+        } catch (UnsupportedJwtException | MalformedJwtException | IllegalArgumentException e) {
+            throw new CustomException(ErrorType.INVALID_APPLE_IDENTITY_TOKEN);
+        }
+    }
+}

--- a/src/main/java/sopt/org/umbbaServer/domain/user/social/apple/verify/EncryptUtils.java
+++ b/src/main/java/sopt/org/umbbaServer/domain/user/social/apple/verify/EncryptUtils.java
@@ -1,0 +1,25 @@
+package sopt.org.umbbaServer.domain.user.social.apple.verify;
+
+import sopt.org.umbbaServer.error.CustomException;
+import sopt.org.umbbaServer.error.ErrorType;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+public class EncryptUtils {
+
+    public static String encrypt(String value) {
+        try {
+            MessageDigest sha256 = MessageDigest.getInstance("SHA-256");
+            byte[] digest = sha256.digest(value.getBytes(StandardCharsets.UTF_8));
+            StringBuilder hexString = new StringBuilder();
+            for (byte b : digest) {
+                hexString.append(String.format("%02x", b));
+            }
+            return hexString.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new CustomException(ErrorType.INVALID_ENCRYPT_COMMUNICATION);
+        }
+    }
+}

--- a/src/main/java/sopt/org/umbbaServer/domain/user/social/apple/verify/PublicKeyGenerator.java
+++ b/src/main/java/sopt/org/umbbaServer/domain/user/social/apple/verify/PublicKeyGenerator.java
@@ -1,0 +1,49 @@
+package sopt.org.umbbaServer.domain.user.social.apple.verify;
+
+import org.springframework.stereotype.Component;
+import org.springframework.util.Base64Utils;
+import sopt.org.umbbaServer.domain.user.social.apple.response.ApplePublicKey;
+import sopt.org.umbbaServer.domain.user.social.apple.response.ApplePublicKeys;
+import sopt.org.umbbaServer.error.CustomException;
+import sopt.org.umbbaServer.error.ErrorType;
+
+import java.math.BigInteger;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.RSAPublicKeySpec;
+import java.util.Map;
+
+@Component
+public class PublicKeyGenerator {
+
+    private static final String SIGN_ALGORITHM_HEADER_KEY = "alg";
+    private static final String KEY_ID_HEADER_KEY = "kid";
+    private static final int POSITIVE_SIGN_NUMBER = 1;
+
+    public PublicKey generatePublicKey(Map<String, String> headers, ApplePublicKeys applePublicKeys) {
+        ApplePublicKey applePublicKey =
+                applePublicKeys.getMatchesKey(headers.get(SIGN_ALGORITHM_HEADER_KEY), headers.get(KEY_ID_HEADER_KEY));
+
+        return generatePublicKeyWithApplePublicKey(applePublicKey);
+    }
+
+    private PublicKey generatePublicKeyWithApplePublicKey(ApplePublicKey publicKey) {
+        byte[] nBytes = Base64Utils.decodeFromUrlSafeString(publicKey.getN());
+        byte[] eBytes = Base64Utils.decodeFromUrlSafeString(publicKey.getE());
+
+        BigInteger n = new BigInteger(POSITIVE_SIGN_NUMBER, nBytes);
+        BigInteger e = new BigInteger(POSITIVE_SIGN_NUMBER, eBytes);
+
+        RSAPublicKeySpec publicKeySpec = new RSAPublicKeySpec(n, e);
+
+        try {
+            KeyFactory keyFactory = KeyFactory.getInstance(publicKey.getKty());
+            return keyFactory.generatePublic(publicKeySpec);
+        } catch (NoSuchAlgorithmException | InvalidKeySpecException exception) {
+            throw new CustomException(ErrorType.CREATE_PUBLIC_KEY_EXCEPTION);
+        }
+    }
+}
+

--- a/src/main/java/sopt/org/umbbaServer/domain/user/social/kakao/KakaoLoginService.java
+++ b/src/main/java/sopt/org/umbbaServer/domain/user/social/kakao/KakaoLoginService.java
@@ -1,0 +1,62 @@
+package sopt.org.umbbaServer.domain.user.social.kakao;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import sopt.org.umbbaServer.domain.user.model.User;
+import sopt.org.umbbaServer.domain.user.social.kakao.feign.KakaoApiClient;
+import sopt.org.umbbaServer.domain.user.social.kakao.feign.KakaoAuthApiClient;
+import sopt.org.umbbaServer.domain.user.social.kakao.response.KakaoAccessTokenResponse;
+import sopt.org.umbbaServer.domain.user.social.kakao.response.KakaoUserResponse;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class KakaoLoginService {
+
+    @Value("${kakao.client-id}")
+    private String CLIENT_ID;
+    @Value("${kakao.authorization-grant-type}")
+    private String GRANT_TYPE;
+    @Value("${kakao.redirect-uri}")
+    private String REDIRECT_URL;
+
+    private final KakaoAuthApiClient kakaoAuthApiClient;
+    private final KakaoApiClient kakaoApiClient;
+
+    public String getKakaoAccessToken(String code) {
+        // Authorization code로 Access Token 불러오기
+        KakaoAccessTokenResponse tokenResponse = kakaoAuthApiClient.getOAuth2AccessToken(
+                GRANT_TYPE,
+                CLIENT_ID,
+                REDIRECT_URL,
+                code
+        );
+        return tokenResponse.getAccessToken();
+        // Refresh 토큰은 필요 없는거 맞나?
+        // 1. 만약 필요하다면 클라한테서 함께 받아온다음
+        // 2. login 메서드 -> setKakaoInfo 메서드 호출할 때 같이 받아오는 작업 필요
+    }
+
+    public String getKakaoId(String socialAccessToken) {
+
+        // Access Token으로 유저 정보 불러오기
+        KakaoUserResponse userResponse = kakaoApiClient.getUserInformation("Bearer " + socialAccessToken);
+
+        String kakaoId = Long.toString(userResponse.getId()); //Social ID를 조회
+
+        return kakaoId;
+    }
+
+    public void setKakaoInfo(User loginUser, String socialAccessToken) {
+
+        // Access Token으로 유저 정보 불러오기
+        KakaoUserResponse userResponse = kakaoApiClient.getUserInformation("Bearer " + socialAccessToken);
+
+        loginUser.updateSocialInfo(userResponse.getKakaoAccount().getProfile().getNickname(),
+                userResponse.getKakaoAccount().getProfile().getProfileImageUrl(),
+                socialAccessToken); //Kakao의 Access 토큰도 매번 업데이트
+    }
+
+}

--- a/src/main/java/sopt/org/umbbaServer/domain/user/social/kakao/feign/KakaoApiClient.java
+++ b/src/main/java/sopt/org/umbbaServer/domain/user/social/kakao/feign/KakaoApiClient.java
@@ -1,0 +1,15 @@
+package sopt.org.umbbaServer.domain.user.social.kakao.feign;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import sopt.org.umbbaServer.domain.user.social.kakao.response.KakaoUserResponse;
+
+@FeignClient(name = "kakaoApiClient", url = "https://kapi.kakao.com")
+public interface KakaoApiClient {
+
+    //Access 토큰을 활용해서 실제 유저 정보를 가져오는 역할
+    @GetMapping(value = "/v2/user/me")
+    KakaoUserResponse getUserInformation(@RequestHeader(HttpHeaders.AUTHORIZATION) String accessToken);
+}

--- a/src/main/java/sopt/org/umbbaServer/domain/user/social/kakao/feign/KakaoAuthApiClient.java
+++ b/src/main/java/sopt/org/umbbaServer/domain/user/social/kakao/feign/KakaoAuthApiClient.java
@@ -1,0 +1,20 @@
+package sopt.org.umbbaServer.domain.user.social.kakao.feign;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import sopt.org.umbbaServer.domain.user.social.kakao.response.KakaoAccessTokenResponse;
+
+@FeignClient(name = "kakaoAuthApiClient", url = "https://kauth.kakao.com")
+public interface KakaoAuthApiClient {
+
+    //Authorization Code를 활용해서 Access Token + Refresh Token을 받아오는 역할
+    @PostMapping(value = "/oauth/token", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+    KakaoAccessTokenResponse getOAuth2AccessToken(
+            @RequestParam("grant_type") String grantType,
+            @RequestParam("client_id") String clientId,
+            @RequestParam("redirect_uri") String redirectUri,
+            @RequestParam("code") String code
+    );
+}

--- a/src/main/java/sopt/org/umbbaServer/domain/user/social/kakao/response/KakaoAccessTokenResponse.java
+++ b/src/main/java/sopt/org/umbbaServer/domain/user/social/kakao/response/KakaoAccessTokenResponse.java
@@ -1,0 +1,20 @@
+package sopt.org.umbbaServer.domain.user.social.kakao.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.*;
+
+@ToString
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class KakaoAccessTokenResponse {
+
+    private String accessToken;
+    private String refreshToken;
+
+    public static KakaoAccessTokenResponse of(String accessToken, String refreshToken) {
+        return new KakaoAccessTokenResponse(accessToken, refreshToken);
+    }
+}

--- a/src/main/java/sopt/org/umbbaServer/domain/user/social/kakao/response/KakaoAccount.java
+++ b/src/main/java/sopt/org/umbbaServer/domain/user/social/kakao/response/KakaoAccount.java
@@ -1,0 +1,15 @@
+package sopt.org.umbbaServer.domain.user.social.kakao.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.*;
+
+@ToString
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class KakaoAccount {
+
+    private KakaoUserProfile profile;
+}

--- a/src/main/java/sopt/org/umbbaServer/domain/user/social/kakao/response/KakaoUserProfile.java
+++ b/src/main/java/sopt/org/umbbaServer/domain/user/social/kakao/response/KakaoUserProfile.java
@@ -1,0 +1,16 @@
+package sopt.org.umbbaServer.domain.user.social.kakao.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.*;
+
+@ToString
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class KakaoUserProfile {
+
+    private String nickname;
+    private String profileImageUrl;
+}

--- a/src/main/java/sopt/org/umbbaServer/domain/user/social/kakao/response/KakaoUserResponse.java
+++ b/src/main/java/sopt/org/umbbaServer/domain/user/social/kakao/response/KakaoUserResponse.java
@@ -1,0 +1,18 @@
+package sopt.org.umbbaServer.domain.user.social.kakao.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.*;
+
+@ToString
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class KakaoUserResponse {
+
+    //받아올 땐 Long이지만, String으로 바꿔서 사용하기
+    private Long id;
+
+    private KakaoAccount kakaoAccount;
+}

--- a/src/main/java/sopt/org/umbbaServer/error/ErrorType.java
+++ b/src/main/java/sopt/org/umbbaServer/error/ErrorType.java
@@ -14,7 +14,7 @@ public enum ErrorType {
      */
     REQUEST_VALIDATION_EXCEPTION(HttpStatus.BAD_REQUEST, "잘못된 요청입니다"),
     VALIDATION_WRONG_TYPE_EXCEPTION(HttpStatus.BAD_REQUEST, "잘못된 타입이 입력되었습니다"),
-    EMPTY_PRINCIPLE(HttpStatus.BAD_REQUEST, "Principle 객체가 없습니다. (null)"),
+    EMPTY_PRINCIPLE_EXCEPTION(HttpStatus.BAD_REQUEST, "Principle 객체가 없습니다. (null)"),
 
     /**
      * 401 UNAUTHORIZED
@@ -27,14 +27,17 @@ public enum ErrorType {
     /**
      * 404 NOT FOUND
      */
-    INVALID_USER(HttpStatus.NOT_FOUND, "유효하지 않은 회원입니다."),
-
+    INVALID_USER(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."),
 
     /**
-     * 409 CONFLICT
+     * About Apple (HttpStatus 고민)
      */
-    ALREADY_EXIST_USER_EXCEPTION(HttpStatus.CONFLICT, "이미 존재하는 유저입니다"),
-
+    INVALID_APPLE_PUBLIC_KEY(HttpStatus.BAD_REQUEST, "Apple JWT 값의 alg, kid 정보가 올바르지 않습니다."),
+    INVALID_APPLE_IDENTITY_TOKEN(HttpStatus.BAD_REQUEST, "Apple OAuth Identity Token 형식이 올바르지 않습니다."),
+    EXPIRED_APPLE_IDENTITY_TOKEN(HttpStatus.BAD_REQUEST, "Apple OAuth 로그인 중 Identity Token 유효기간이 만료됐습니다."),
+    INVALID_APPLE_CLAIMS(HttpStatus.BAD_REQUEST, "Apple OAuth Claims 값이 올바르지 않습니다."),
+    INVALID_ENCRYPT_COMMUNICATION(HttpStatus.BAD_REQUEST, "Apple OAuth 통신 암호화 과정 중 문제가 발생했습니다."),
+    CREATE_PUBLIC_KEY_EXCEPTION(HttpStatus.BAD_REQUEST, "Apple OAuth 로그인 중 public verify 생성에 문제가 발생했습니다."),
 
     /**
      * 500 INTERNAL SERVER ERROR

--- a/src/main/java/sopt/org/umbbaServer/error/SuccessType.java
+++ b/src/main/java/sopt/org/umbbaServer/error/SuccessType.java
@@ -20,7 +20,6 @@ public enum SuccessType {
     /**
      * 201 CREATED
      */
-    CREATE_BOARD_SUCCESS(HttpStatus.CREATED, "게시물 생성이 완료됐습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/sopt/org/umbbaServer/error/SuccessType.java
+++ b/src/main/java/sopt/org/umbbaServer/error/SuccessType.java
@@ -13,7 +13,7 @@ public enum SuccessType {
      * 200 OK
      */
     LOGIN_SUCCESS(HttpStatus.OK, "로그인에 성공했습니다."),
-    REFRESH_SUCCESS(HttpStatus.OK, "Access 토큰 재발급에 성공했습니다."),
+    REISSUE_SUCCESS(HttpStatus.OK, "Access 토큰 재발급에 성공했습니다."),
     LOGOUT_SUCCESS(HttpStatus.OK, "로그아웃에 성공했습니다."),
     KAKAO_ACCESS_TOKEN_SUCCESS(HttpStatus.OK, "카카오 엑세스 토큰을 가져오는데 성공했습니다"),
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -22,14 +22,17 @@ spring:
       ddl-auto: update
     properties:
       hibernate:
-        format_sql:true
+        format_sql: true
 
 kakao:
   client-id: ${kakao-id}
   authorization-grant-type: authorization_code
   redirect-uri: ${kakao-redirect}
+
 apple:
-  url: ${apple-url}
+  iss: ${apple-iss}
+  client-id: ${apple-id}
+  nonce: ${apple-nonce}
 
 jwt:
   secret: ${jwt-secret}


### PR DESCRIPTION
## 📌 관련 이슈
closed #3 

## ✨ 어떤 이유로 변경된 내용인지
- OpenFeign을 활용한 OAuth 2.0 카카오, 애플 소셜 로그인 구현
- Spring Security를 활용해 JWT 엑세스 토큰 관리
- Redis를 활용해 리프레시 토큰 관리

## 🙏 검토 혹은 리뷰어에게 남기고 싶은 말
- [x] Practice 레포에서 완성한 코드 추가
- [x] 코드 리뷰를 바탕으로 리팩토링