### PR TITLE
[FIX] deploy.sh 실행에서 사용하는 API들 SecurityConfig에서 풀어주기

### DIFF
--- a/src/main/java/sopt/org/umbbaServer/config/SecurityConfig.java
+++ b/src/main/java/sopt/org/umbbaServer/config/SecurityConfig.java
@@ -24,7 +24,7 @@ public class SecurityConfig {
     private static final String[] AUTH_WHITELIST = {
             "/kakao/**", "/login", "/reissue",
 //          "/log-out",
-            "/test"
+            "/test", "/profile", "/health", "/actuator/health"
     };
 
     @Bean


### PR DESCRIPTION
## 📌 관련 이슈
closed #5

## ✨ 어떤 이유로 변경된 내용인지
- CodeDeploy에서 deploy.sh를 실행할 때, /profile과 /health, /actuator/health를 호출하는데,
- 스프링 Security 설정파일의 AUTH_WHITELIST 배열에 등록해놓지 않았다보니 호출할 수 없는 오류 발생

## 🙏 검토 혹은 리뷰어에게 남기고 싶은 말
- deploy.sh 파일에서 사용하는 API들 SecurityConfig AUTH_WHITELIST 배열에 등록 완료
