### PR TITLE
[FEAT] 일일문답 페이지 질문 답변 API

### DIFF
--- a/src/main/java/sopt/org/umbbaServer/domain/qna/controller/QnAController.java
+++ b/src/main/java/sopt/org/umbbaServer/domain/qna/controller/QnAController.java
@@ -2,14 +2,16 @@ package sopt.org.umbbaServer.domain.qna.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ResponseStatus;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import sopt.org.umbbaServer.domain.parentchild.controller.dto.request.OnboardingInviteRequestDto;
+import sopt.org.umbbaServer.domain.qna.controller.dto.request.TodayAnswerRequestDto;
+import sopt.org.umbbaServer.domain.qna.controller.dto.response.TodayQnAResponseDto;
 import sopt.org.umbbaServer.domain.qna.service.QnAService;
 import sopt.org.umbbaServer.global.common.dto.ApiResponse;
 import sopt.org.umbbaServer.global.config.jwt.JwtProvider;
 import sopt.org.umbbaServer.global.exception.SuccessType;
 
+import javax.validation.Valid;
 import java.security.Principal;
 
 @RestController
@@ -20,7 +22,7 @@ public class QnAController {
 
     @GetMapping("/qna")
     @ResponseStatus(HttpStatus.OK)
-    public ApiResponse getTodayQna(Principal principal) {
+    public ApiResponse<TodayQnAResponseDto> getTodayQna(Principal principal) {
 
         return ApiResponse.success(SuccessType.GET_TODAY_QNA_SUCCESS, qnAService.getTodayQnA(JwtProvider.getUserFromPrincial(principal)));
     }
@@ -31,5 +33,16 @@ public class QnAController {
         qnAService.createQnA();
 
         return ApiResponse.success(SuccessType.GET_TODAY_QNA_SUCCESS);
+    }
+
+    @PostMapping("/qna")
+    @ResponseStatus(HttpStatus.CREATED)
+    public ApiResponse answerTodayQuestion(
+            Principal principal,
+            @Valid @RequestBody TodayAnswerRequestDto request) {
+
+        qnAService.answerTodayQuestion(request, JwtProvider.getUserFromPrincial(principal));
+
+        return ApiResponse.success(SuccessType.ANSWER_TODAY_QUESTION_SUCCESS);
     }
 }

--- a/src/main/java/sopt/org/umbbaServer/domain/qna/controller/QnAController.java
+++ b/src/main/java/sopt/org/umbbaServer/domain/qna/controller/QnAController.java
@@ -3,7 +3,6 @@ package sopt.org.umbbaServer.domain.qna.controller;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
-import sopt.org.umbbaServer.domain.parentchild.controller.dto.request.OnboardingInviteRequestDto;
 import sopt.org.umbbaServer.domain.qna.controller.dto.request.TodayAnswerRequestDto;
 import sopt.org.umbbaServer.domain.qna.controller.dto.response.TodayQnAResponseDto;
 import sopt.org.umbbaServer.domain.qna.service.QnAService;

--- a/src/main/java/sopt/org/umbbaServer/domain/qna/controller/dto/request/TodayAnswerRequestDto.java
+++ b/src/main/java/sopt/org/umbbaServer/domain/qna/controller/dto/request/TodayAnswerRequestDto.java
@@ -8,8 +8,6 @@ import lombok.NoArgsConstructor;
 import javax.validation.constraints.NotBlank;
 
 @Getter
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
-@NoArgsConstructor
 public class TodayAnswerRequestDto {
 
     @NotBlank // null, "", " "을 모두 허용하지 X

--- a/src/main/java/sopt/org/umbbaServer/domain/qna/controller/dto/request/TodayAnswerRequestDto.java
+++ b/src/main/java/sopt/org/umbbaServer/domain/qna/controller/dto/request/TodayAnswerRequestDto.java
@@ -1,0 +1,17 @@
+package sopt.org.umbbaServer.domain.qna.controller.dto.request;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor
+public class TodayAnswerRequestDto {
+
+    @NotBlank // null, "", " "을 모두 허용하지 X
+    String answer;
+}

--- a/src/main/java/sopt/org/umbbaServer/domain/qna/model/QnA.java
+++ b/src/main/java/sopt/org/umbbaServer/domain/qna/model/QnA.java
@@ -41,9 +41,11 @@ public class QnA extends AuditingTimeEntity {
 
     public void saveParentAnswer(String answer) {
         this.parentAnswer = answer;
+        this.isParentAnswer = true;
     }
 
     public void saveChildAnswer(String answer) {
         this.childAnswer = answer;
+        this.isChildAnswer = true;
     }
 }

--- a/src/main/java/sopt/org/umbbaServer/domain/qna/model/QnA.java
+++ b/src/main/java/sopt/org/umbbaServer/domain/qna/model/QnA.java
@@ -38,4 +38,12 @@ public class QnA extends AuditingTimeEntity {
     public boolean isChildAnswer() {
         return isChildAnswer;
     }
+
+    public void saveParentAnswer(String answer) {
+        this.parentAnswer = answer;
+    }
+
+    public void saveChildAnswer(String answer) {
+        this.childAnswer = answer;
+    }
 }

--- a/src/main/java/sopt/org/umbbaServer/domain/qna/service/QnAService.java
+++ b/src/main/java/sopt/org/umbbaServer/domain/qna/service/QnAService.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import sopt.org.umbbaServer.domain.parentchild.model.Parentchild;
 import sopt.org.umbbaServer.domain.parentchild.repository.ParentchildRepository;
+import sopt.org.umbbaServer.domain.qna.controller.dto.request.TodayAnswerRequestDto;
 import sopt.org.umbbaServer.domain.qna.controller.dto.response.TodayQnAResponseDto;
 import sopt.org.umbbaServer.domain.qna.model.QnA;
 import sopt.org.umbbaServer.domain.qna.model.Question;
@@ -42,6 +43,22 @@ public class QnAService {
     }
 
     @Transactional
+    public void answerTodayQuestion(TodayAnswerRequestDto request, Long userId) {
+        User myUser = getUserById(userId);
+        Parentchild parentchild = getParentchildByUser(myUser);
+        QnA todayQnA = getQnAByParentchild(parentchild);
+        User opponentUser = getOpponentByParentchild(parentchild, userId);
+
+        boolean isMeChild = myUser.getBornYear() >= opponentUser.getBornYear();
+
+        if (isMeChild) {
+            todayQnA.saveChildAnswer(request.getAnswer());
+        } else {
+            todayQnA.saveParentAnswer(request.getAnswer());
+        }
+    }
+
+    @Transactional
     public void createQnA() {
         QnA newQnA = QnA.builder()
                 .question(questionRepository.findById(1L).get()) // 필터 로직 추가되어야함
@@ -55,6 +72,8 @@ public class QnAService {
         Parentchild parentchild = parentchildRepository.findById(1L).get();
         parentchild.addQna(newQnA);
     }
+
+    // 리팩토링을 위해 아래로 뺀 메서드들
 
     private User getUserById(Long userId) {
         return userRepository.findById(userId)

--- a/src/main/java/sopt/org/umbbaServer/global/exception/SuccessType.java
+++ b/src/main/java/sopt/org/umbbaServer/global/exception/SuccessType.java
@@ -22,7 +22,7 @@ public enum SuccessType {
      * 201 CREATED
      */
     CREATE_PARENT_CHILD_SUCCESS(HttpStatus.CREATED, "온보딩 정보를 입력받아 부모자식 관계를 생성하는 데 성공했습니다."),
-
+    ANSWER_TODAY_QUESTION_SUCCESS(HttpStatus.CREATED, "오늘의 일일문답에 답변을 완료하였습니다."),
 
     ;
 


### PR DESCRIPTION
## 📌 관련 이슈
closed #19

## ✨ 어떤 이유로 변경된 내용인지
- 일일문답 페이지에서 질문에 대한 답변을 처리해주는 API 개발
- 상대방에게 푸시알림 나가는 기능은 추후 구현

## 🙏 검토 혹은 리뷰어에게 남기고 싶은 말
- JPQL 최적화는 추후에 구현하겠습니다!
