### PR TITLE
[FEAT] FCM 푸시 서버 구축

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-application.yml
+firebase/
 
 HELP.md
 .gradle

--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,9 @@ dependencies {
 	// random String
 	implementation 'org.apache.commons:commons-lang3'
 
+	// FCM
+	implementation 'com.google.firebase:firebase-admin:9.1.1'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/sopt/org/umbbaServer/domain/user/model/User.java
+++ b/src/main/java/sopt/org/umbbaServer/domain/user/model/User.java
@@ -53,6 +53,14 @@ public class User extends AuditingTimeEntity {
         this.refreshToken = refreshToken;
     }
 
+    // ** FCM 푸시 알림 관련 **
+    private String firebaseToken;  // registration+token
+
+    public void updateFirebaseToken(String firebaseToken) {
+        this.firebaseToken = firebaseToken;
+    }
+
+
     // ** 소셜 로그인 관련 **
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)

--- a/src/main/java/sopt/org/umbbaServer/domain/user/repository/UserRepository.java
+++ b/src/main/java/sopt/org/umbbaServer/domain/user/repository/UserRepository.java
@@ -17,6 +17,8 @@ public interface UserRepository extends Repository<User, Long> {
     Optional<User> findById(Long id);
     boolean existsBySocialPlatformAndSocialId(SocialPlatform socialPlatform, String socialId);
     Optional<User> findBySocialPlatformAndSocialId(SocialPlatform socialPlatform, String socialId);
+    Optional<User> findByFirebaseToken(String firebaseToken);
+
 
     /*@Query(value = "select user " +
             "from User user " +

--- a/src/main/java/sopt/org/umbbaServer/global/config/FCMConfig.java
+++ b/src/main/java/sopt/org/umbbaServer/global/config/FCMConfig.java
@@ -1,0 +1,106 @@
+package sopt.org.umbbaServer.global.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.messaging.*;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import sopt.org.umbbaServer.global.exception.CustomException;
+import sopt.org.umbbaServer.global.exception.ErrorType;
+import sopt.org.umbbaServer.global.util.fcm.controller.dto.FCMNotificationRequestDto;
+
+import javax.annotation.PostConstruct;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
+@Slf4j
+@Configuration
+public class FCMConfig {
+
+    @Value("${fcm.key.path}")
+    private String SERVICE_ACCOUNT_JSON;
+
+    // SDK 초기화: ADC를 사용하여 사용자 인증 정보 제공 -> 보내기 요청 승인 후에 사용 가능
+    @PostConstruct
+    public void init() {
+        try {
+            Resource resource = new ClassPathResource(SERVICE_ACCOUNT_JSON);
+            FileInputStream serviceAccount = new FileInputStream(resource.getFile());
+
+            FirebaseOptions options = FirebaseOptions.builder()
+                    .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                    .build();
+
+            FirebaseApp.initializeApp(options);
+        } catch (IOException e) {
+            log.error("파이어베이스 서버와의 연결에 실패했습니다.");
+            throw new CustomException(ErrorType.FIREBASE_CONNECTION_ERROR);
+        }
+    }
+
+    // 여러 개의 파이어베이스 앱을 사용하는 경우
+    @Bean
+    FirebaseMessaging firebaseMessaging() throws IOException {
+
+        ClassPathResource resource = new ClassPathResource(SERVICE_ACCOUNT_JSON);
+        InputStream refreshToken = resource.getInputStream();
+
+        FirebaseApp firebaseApp = null;
+        List<FirebaseApp> firebaseAppList = FirebaseApp.getApps();
+
+        if (!firebaseAppList.isEmpty() && firebaseAppList != null) {
+            for (FirebaseApp app : firebaseAppList) {
+                if (app.getName().equals(FirebaseApp.DEFAULT_APP_NAME)) {
+                    firebaseApp = app;
+                }
+            }
+        } else {
+            FirebaseOptions options = FirebaseOptions.builder()
+                    .setCredentials(GoogleCredentials.fromStream(refreshToken))
+                    .build();
+
+            firebaseApp = FirebaseApp.initializeApp(options);
+        }
+
+        return FirebaseMessaging.getInstance(firebaseApp);
+
+
+    }
+
+    // TODO 플랫폼마다 별도의 설정이 필요한 경우 사용
+
+    // Android
+    public AndroidConfig TokenAndroidConfig(FCMNotificationRequestDto request) {
+        return AndroidConfig.builder()
+//                .setCollapseKey(request.getCollapseKey())
+                .setNotification(AndroidNotification.builder()
+                        .setTitle(request.getTitle())
+                        .setBody(request.getBody())
+                        .build())
+                .build();
+    }
+
+    // Apple
+    public ApnsConfig TokenApnsConfig(FCMNotificationRequestDto request) {
+        return ApnsConfig.builder()
+                .setAps(Aps.builder()
+                        .setAlert(
+                                ApsAlert.builder()
+                                        .setTitle(request.getTitle())
+                                        .setBody(request.getBody())
+//                                        .setLaunchImage(request.getImgUrl())
+                                        .build()
+                        )
+//                        .setCategory(request.getCollapseKey())
+                        .setSound("default")
+                        .build())
+                .build();
+    }
+}

--- a/src/main/java/sopt/org/umbbaServer/global/config/ScheduleConfig.java
+++ b/src/main/java/sopt/org/umbbaServer/global/config/ScheduleConfig.java
@@ -1,0 +1,20 @@
+package sopt.org.umbbaServer.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+/**
+ * 특정 시간대에 알림을 보내주기 위해 Spring이 제공하는 TaskScheduler를 빈으로 등록
+ */
+@Configuration
+public class ScheduleConfig {
+
+    private final int POOL_SIZE = 10;
+
+    public TaskScheduler scheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(POOL_SIZE);
+        return scheduler;
+    }
+}

--- a/src/main/java/sopt/org/umbbaServer/global/exception/ErrorType.java
+++ b/src/main/java/sopt/org/umbbaServer/global/exception/ErrorType.java
@@ -31,6 +31,7 @@ public enum ErrorType {
     INVALID_SOCIAL_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 소셜 엑세스 토큰입니다."),
     EMPTY_PRINCIPLE_EXCEPTION(HttpStatus.UNAUTHORIZED, "엑세스 토큰이 비어있거나, 유효하지 않은 엑세스 토큰입니다."),
     INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 엑세스 토큰입니다, 엑세스 토큰을 재발급 받아주세요."),
+    INVALID_FIREBASE_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 파이어베이스 토큰입니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 리프레시 토큰입니다, 다시 로그인을 해주세요."),
     NOT_MATCH_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "일치하지 않는 리프레시 토큰입니다."),
 
@@ -62,7 +63,8 @@ public enum ErrorType {
      * 500 INTERNAL SERVER ERROR
      */
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 서버 에러가 발생했습니다"),
-
+    FIREBASE_CONNECTION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "파이어베이스 서버와의 연결에 실패했습니다."),
+    FAIL_TO_SEND_PUSH_ALARM(HttpStatus.INTERNAL_SERVER_ERROR, "푸시 알림 메세지 전송에 실패했습니다."),
 
     ;
 

--- a/src/main/java/sopt/org/umbbaServer/global/exception/SuccessType.java
+++ b/src/main/java/sopt/org/umbbaServer/global/exception/SuccessType.java
@@ -23,6 +23,7 @@ public enum SuccessType {
     MATCH_PARENT_CHILD_SUCCESS(HttpStatus.OK, "부모자식 관계 매칭에 성공했습니다."),
     GET_MAIN_HOME_SUCCESS(HttpStatus.OK, "메인 홈 화면 정보 불러오기에 성공했습니다."),
     GET_INVITE_CODE_SUCCESS(HttpStatus.OK, "초대장을 보낼 코드 조회에 성공했습니다."),
+    PUSH_ALARM_SUCCESS(HttpStatus.OK, "푸시알림 전송에 성공했습니다."),
 
 
     /**

--- a/src/main/java/sopt/org/umbbaServer/global/util/fcm/FCMScheduler.java
+++ b/src/main/java/sopt/org/umbbaServer/global/util/fcm/FCMScheduler.java
@@ -1,0 +1,74 @@
+package sopt.org.umbbaServer.global.util.fcm;
+
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.Notification;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import sopt.org.umbbaServer.domain.qna.dao.QnADao;
+import sopt.org.umbbaServer.global.exception.CustomException;
+import sopt.org.umbbaServer.global.exception.ErrorType;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FCMScheduler {
+
+//    @Value("${fcm.key.firebase-create-scoped}")
+    String firebaseCreateScoped;  // TODO 미사용 -> 삭제할 것
+
+    @Value("${fcm.topic}")
+    String topic;
+
+    private final QnADao qnADao;
+
+
+    @Scheduled(cron = "0 0 23 * * ?")
+    public void pushTodayQna() {
+        try {
+            log.info("오늘의 질문 알람 - 유저마다 보내는 시간 다름");
+        /*List<QnA> qnAList = qnADao.findQnASByUserId(userId).orElseThrow(
+                () -> new CustomException(ErrorType.USER_HAVE_NO_QNALIST)
+        );
+        QnA lastQna = qnAList.get(qnAList.size()-1);*/
+            pushAlarm(PushRequest.sendTodayQna("section", "question"));
+        } catch (FirebaseMessagingException e) {
+            log.error("푸시메시지 전송 실패!: {}", e.getMessage());
+            throw new CustomException(ErrorType.FAIL_TO_SEND_PUSH_ALARM);
+        }
+    }
+
+    public void pushOpponentReply() {
+        try {
+            log.info("오늘의 질문 알람 - 유저마다 보내는 시간 다름");
+        /*List<QnA> qnAList = qnADao.findQnASByUserId(userId).orElseThrow(
+                () -> new CustomException(ErrorType.USER_HAVE_NO_QNALIST)
+        );
+        QnA lastQna = qnAList.get(qnAList.size()-1);*/
+            pushAlarm(PushRequest.sendTodayQna("section", "question"));
+        } catch (FirebaseMessagingException e) {
+            log.error("푸시메시지 전송 실패!: {}", e.getMessage());
+            throw new CustomException(ErrorType.FAIL_TO_SEND_PUSH_ALARM);
+        }
+    }
+
+    private void pushAlarm(PushRequest.PushMessage data) throws FirebaseMessagingException {
+
+        Notification notification = Notification.builder()
+                .setTitle(data.getTitle())
+                .setBody(data.getBody())
+                .build();
+
+        Message message = Message.builder()
+                .setTopic(topic)
+                .setNotification(notification)
+                .build();
+
+        FirebaseMessaging.getInstance().send(message);
+    }
+
+}

--- a/src/main/java/sopt/org/umbbaServer/global/util/fcm/FCMService.java
+++ b/src/main/java/sopt/org/umbbaServer/global/util/fcm/FCMService.java
@@ -1,0 +1,144 @@
+package sopt.org.umbbaServer.global.util.fcm;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.Notification;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.*;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import sopt.org.umbbaServer.domain.user.model.User;
+import sopt.org.umbbaServer.domain.user.repository.UserRepository;
+import sopt.org.umbbaServer.global.exception.CustomException;
+import sopt.org.umbbaServer.global.exception.ErrorType;
+import sopt.org.umbbaServer.global.util.fcm.controller.dto.FCMMessage;
+import sopt.org.umbbaServer.global.util.fcm.controller.dto.FCMNotificationRequestDto;
+
+import java.io.IOException;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FCMService {
+
+    @Value("${fcm.key.path}")
+    private String SERVICE_ACCOUNT_JSON;
+    @Value("${fcm.api.url}")
+    private String FCM_API_URL;
+
+    private final UserRepository userRepository;
+    private final ObjectMapper objectMapper;
+
+
+    // Firebase에서 Access Token 가져오기
+    private String getAccessToken() throws IOException {
+
+        GoogleCredentials googleCredentials = GoogleCredentials
+                .fromStream(new ClassPathResource(SERVICE_ACCOUNT_JSON).getInputStream())
+                .createScoped(List.of("https://www.googleapis.com/auth/cloud-platform"));  // TODO cloud-platform으로 변경
+        googleCredentials.refreshIfExpired();
+        log.info("getAccessToken() - googleCredentials: {} ", googleCredentials.getAccessToken().getTokenValue());
+
+        return googleCredentials.getAccessToken().getTokenValue();
+    }
+
+    // FCM Service에 메시지를 수신하는 함수 (헤더와 바디 직접 만들기)
+    @Transactional
+    public String sendMessageTo(FCMNotificationRequestDto request, Long userId) throws IOException {
+
+        // TODO 같은 Parentchild ID를 가진 User를 찾은 후, 이들에 대한 토큰 리스트로 동일한 알림 메시지 전송하도록
+        User user = userRepository.findById(userId).orElseThrow(
+                () -> new CustomException(ErrorType.INVALID_USER)
+        );
+        user.updateFirebaseToken(request.getTargetToken());
+
+        String message = makeMessage(request);
+
+        OkHttpClient client = new OkHttpClient();
+        RequestBody requestBody = RequestBody.create(message, MediaType.get("application/json; charset=utf-8"));
+        Request httpRequest = new Request.Builder()
+                .url(FCM_API_URL)
+                .post(requestBody)
+                .addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + getAccessToken())
+                .addHeader(HttpHeaders.CONTENT_TYPE, "application/json; UTF-8")
+                .build();
+
+        Response response = client.newCall(httpRequest).execute();
+
+        log.info("알림 전송: {}", response.body().string());
+        return "알림을 성공적으로 전송했습니다. targetUserId = " + request.getTargetToken();
+    }
+
+    // 요청 파라미터를 FCM의 body 형태로 만들어주는 메서드
+    private String makeMessage(FCMNotificationRequestDto request) throws JsonProcessingException {
+
+        FCMMessage fcmMessage = FCMMessage.builder()
+                .message(FCMMessage.Message.builder()
+                        .token(request.getTargetToken())
+                        .notification(FCMMessage.Notification.builder()
+                                .title(request.getTitle())
+                                .body(request.getBody())
+                                .image(null)
+                                .build())
+                        .build()
+                ).validateOnly(false)
+                .build();
+
+        return objectMapper.writeValueAsString(fcmMessage);
+    }
+
+
+
+    // 단일 기기에 알림 메시지 전송
+    public String sendNotificationByToken(FCMNotificationRequestDto request) {
+
+        // TODO 같은 Parentchild ID를 가진 User를 찾은 후, 이들에 대한 토큰 리스트로 동일한 알림 메시지 전송하도록
+        User user = userRepository.findByFirebaseToken(request.getTargetToken()).orElseThrow(
+                () -> new CustomException(ErrorType.INVALID_USER)
+        );
+
+        if (user.getFirebaseToken() != null) {
+
+            Notification notification = Notification.builder()
+                    .setTitle(request.getTitle())
+                    .setBody(request.getBody())
+                    .build();
+
+            // 메시지 만들기 TODO List<Message> 로도 구현 가능
+            Message message = Message.builder()
+                    .setToken(user.getFirebaseToken())
+                    .setNotification(notification)
+//                    .putAllData(request.getData())
+                    .build();
+
+            try {
+                FirebaseMessaging.getInstance().send(message);
+                return "알림을 성공적으로 전송했습니다. targetUserId = " + request.getTargetToken();
+            } catch (FirebaseMessagingException e) {
+                log.error("알림 전송 실패 - {}", e);
+                return "알림 전송에 실패했습니다. targetUserId = " + request.getTargetToken();
+            }
+        }
+
+        throw new CustomException(ErrorType.INVALID_FIREBASE_TOKEN);
+    }
+
+    // 다수의 기기에 알림 메시지 전송
+    /*public void multipleSendByToken(FCMNotificationRequestDto request) throws FirebaseMessagingException {
+
+        List<String> tokenList = IntStream.rangeClosed(1, 30).mapToObj(
+                index -> request.getFire
+        )
+    }*/
+
+
+}

--- a/src/main/java/sopt/org/umbbaServer/global/util/fcm/PushRequest.java
+++ b/src/main/java/sopt/org/umbbaServer/global/util/fcm/PushRequest.java
@@ -1,0 +1,53 @@
+package sopt.org.umbbaServer.global.util.fcm;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class PushRequest {
+
+    @Getter
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    public enum PushMessage {
+
+        // 새로운 주제가 도착했을 떄
+        TODAY_QNA("로부터 교신이 도착했어요", "에 대한 질문에 답변하고 추억을 나눠보세요 ☺️(수신거부 : 설정 - 푸시알림 off)"),
+
+
+        // 주제에 대한 상대의 답변이 입력되었을 때
+        OPPONENT_REPLY("📞상대방이 교신에 응답했어요", "에 대한 상대의 답변을 확인해 볼까요? ☺️ ️(수신거부 : 설정 - 푸시알림 off)");
+
+        private String title;
+        private String body;
+
+        public void setTitle(String section) {
+            this.title = "📞 " + section + this.title;
+        }
+
+        public void setBody(String question) {
+            this.body = question + this.body;
+        }
+    }
+
+
+    public static PushMessage sendTodayQna(String section, String question) {
+
+        PushMessage result = PushMessage.TODAY_QNA;
+        result.setTitle(section);
+        result.setBody(question);
+
+        return result;
+    }
+
+    public static PushMessage sendOpponentReply(String question) {
+
+        PushMessage result = PushMessage.OPPONENT_REPLY;
+        result.setBody(question);
+
+        return result;
+    }
+
+
+}

--- a/src/main/java/sopt/org/umbbaServer/global/util/fcm/controller/FCMController.java
+++ b/src/main/java/sopt/org/umbbaServer/global/util/fcm/controller/FCMController.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.*;
 import sopt.org.umbbaServer.global.common.dto.ApiResponse;
 import sopt.org.umbbaServer.global.config.jwt.JwtProvider;
 import sopt.org.umbbaServer.global.exception.SuccessType;
+import sopt.org.umbbaServer.global.util.fcm.FCMScheduler;
 import sopt.org.umbbaServer.global.util.fcm.FCMService;
 import sopt.org.umbbaServer.global.util.fcm.controller.dto.FCMNotificationRequestDto;
 
@@ -18,12 +19,20 @@ import java.security.Principal;
 public class FCMController {
 
     private final FCMService fcmService;
+    private final FCMScheduler fcmScheduler;
 
     @PostMapping
     @ResponseStatus(HttpStatus.OK)
     public ApiResponse sendNotificationByToken(@RequestBody FCMNotificationRequestDto request, Principal principal) throws IOException {
 
         return ApiResponse.success(SuccessType.PUSH_ALARM_SUCCESS, fcmService.sendMessageTo(request, JwtProvider.getUserFromPrincial(principal)));
+    }
+
+    @PostMapping("/qna")
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResponse sendScheduledTest() {
+        fcmScheduler.pushTodayQna();
+        return ApiResponse.success(SuccessType.PUSH_ALARM_SUCCESS);
     }
 
 }

--- a/src/main/java/sopt/org/umbbaServer/global/util/fcm/controller/FCMController.java
+++ b/src/main/java/sopt/org/umbbaServer/global/util/fcm/controller/FCMController.java
@@ -1,0 +1,29 @@
+package sopt.org.umbbaServer.global.util.fcm.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import sopt.org.umbbaServer.global.common.dto.ApiResponse;
+import sopt.org.umbbaServer.global.config.jwt.JwtProvider;
+import sopt.org.umbbaServer.global.exception.SuccessType;
+import sopt.org.umbbaServer.global.util.fcm.FCMService;
+import sopt.org.umbbaServer.global.util.fcm.controller.dto.FCMNotificationRequestDto;
+
+import java.io.IOException;
+import java.security.Principal;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/alarm")
+public class FCMController {
+
+    private final FCMService fcmService;
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResponse sendNotificationByToken(@RequestBody FCMNotificationRequestDto request, Principal principal) throws IOException {
+
+        return ApiResponse.success(SuccessType.PUSH_ALARM_SUCCESS, fcmService.sendMessageTo(request, JwtProvider.getUserFromPrincial(principal)));
+    }
+
+}

--- a/src/main/java/sopt/org/umbbaServer/global/util/fcm/controller/dto/FCMMessage.java
+++ b/src/main/java/sopt/org/umbbaServer/global/util/fcm/controller/dto/FCMMessage.java
@@ -1,0 +1,83 @@
+package sopt.org.umbbaServer.global.util.fcm.controller.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * - Request
+ * {
+ *   "validate_only": boolean,
+ *   "message": {
+ *     object (Message)
+ *   }
+ * }
+ *
+ *
+ * - Message
+ * {
+ *   "name": string,
+ *   "data": {
+ *     string: string,
+ *     ...
+ *   },
+ *   "notification": {   ✅모든 플랫폼에서 사용할 기본 알림 템플릿
+ *     object (Notification)
+ *   },
+ *   "android": {    FCM 연결 서버를 통해 전송된 메시지에 대한 Android 전용 옵션 TODO 이 부분을 서버 측에서 설정해줘야 하는지?
+ *     object (AndroidConfig)
+ *   },
+ *   "webpush": {   Web 푸시 알림을 위한 webpush 프로토콘 옵션
+ *     object (WebpushConfig)
+ *   },
+ *   "apns": {      Apple 푸시 알림 서비스 특정 옵션  TODO 이 부분을 서버 측에서 설정해줘야 하는지?
+ *     object (ApnsConfig)
+ *   },
+ *   "fcm_options": {  모든 플랫폼에서 사용할 FCM SDK 기능 옵션용 템플릿
+ *     object (FcmOptions)
+ *   },
+ *
+ *   // Union field target can be only one of the following:
+ *   "token": string,    메시지를 보낼 등록 토큰 (특정 클라이언트 대상)
+ *   "topic": string,    Topic 발행의 경우, 사용
+ *   "condition": string
+ *   // End of list of possible types for union field target.
+ * }
+ */
+@Builder
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class FCMMessage {
+
+    private boolean validateOnly;
+    private Message message;
+
+    @Builder
+    @AllArgsConstructor
+    @Getter
+    public static class Message {
+        private Notification notification;   // 모든 모바일 OS에 통합으로 사용할 수 있는 Notification
+        private String token;   // 특정 디바이스(클라이언트)에 알림을 보내기 위한 토큰
+//        private Data data;
+    }
+
+    @Builder
+    @AllArgsConstructor
+    @Getter
+    public static class Notification {
+        private String title;
+        private String body;
+        private String image;
+    }
+
+    @Builder
+    @AllArgsConstructor
+    @Getter
+    public static class Data {
+        private String name;
+        private String description;
+    }
+
+
+}

--- a/src/main/java/sopt/org/umbbaServer/global/util/fcm/controller/dto/FCMNotificationRequestDto.java
+++ b/src/main/java/sopt/org/umbbaServer/global/util/fcm/controller/dto/FCMNotificationRequestDto.java
@@ -1,0 +1,14 @@
+package sopt.org.umbbaServer.global.util.fcm.controller.dto;
+
+import lombok.*;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class FCMNotificationRequestDto {
+
+    private String targetToken;
+    private String title;
+    private String body;
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -43,6 +43,18 @@ slack:
   webhook:
     url: ${slack-url}
 
+fcm:
+  key:
+    path: ${fcm-json-path}
+    scope: ${fcm-scope}
+  #    firebase-create-scoped: "https://www.googleapis.com/auth/firebase.messaging"
+  api:
+    url: ${fcm-api-url}
+  topic:
+    "qna_notification"
+
+
+
 logging:
   level:
     org:


### PR DESCRIPTION
<!-- - 
❗️ PR 제목은 아래의 형식을 맞춰주세요 
- [FEAT] : 기능 추가
- [FIX] : 에러 수정, 버그 수정
- [CHORE] : gradle 세팅, 위의 것 이외에 거의 모든 것
- [DOCS] : README, 문서
- [REFACTOR] : 코드 리펙토링 (기능 변경 없이 코드만 수정할 때)
- [MODIFY] : 코드 수정 (기능의 변화가 있을 때)
-->

## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
close #38 

## ✨ 어떤 이유로 변경된 내용인지
<!-- 어떤 기능을 만들기 위한 내용인지 적어주세요 -->
<!-- 그게 아닌 경우에는 어떤 문제를 해결하기 위한 것인지 적어주세요 -->
- 클라이언트 (유저)마다 고유하게 가지는 FCM 토큰으로 요청을 받아 해당 기기로 푸시 메세지를 전송하는 기능을 구현
- 해당 토큰은 처음 요청을 보낼 때 유저의 DB (서버)에 저장해두고 이후 주기적인 알림 전송 등에 사용할 것
- 고정 메세지 템플릿에 대한 enum과 해당 enum에 추가적인 정보를 붙여서 문자열을 생성하기 위해 setter 메서드를 이용함
- 아직 애플에서의 테스트만 완료된 상태라 Android, Apple 각각에 대해 config를 커스텀할 수 있게 주석처리를 해둔 상황
- 우리 서비스의 특성상 부모, 자식 쌍으로 알림 메세지를 전송하는 경우가 많기에, 아직 단일 기기(1:1) 전송으로 구현된 부분을 다수 기기 전송으로 수정할 것 -> 주석처리로 살짝 남아있음

## 🙏 검토 혹은 리뷰어에게 남기고 싶은 말
- FCM 관련 서비스 로직을 처리하는 부분이 FCMService, FCMScheduler로 두 군데인데 이를 하나로 합칠 것인지, 아니면 주기적 알람이랑 특정 API 호출 시(ex. 상대 측 답변 완료 알림) 보내는 알람을 구분해둘지? 어떤 게 더 좋을까요
- application.yml의 정리가 아직은 필요한 상황이라 리뷰 후에 수정사항 반영해서 머지하겠습니다!