### PR TITLE
[FIX] 온보딩 dto 관련 버그 수정

### DIFF
--- a/src/main/java/sopt/org/umbbaServer/domain/parentchild/controller/dto/request/OnboardingInviteRequestDto.java
+++ b/src/main/java/sopt/org/umbbaServer/domain/parentchild/controller/dto/request/OnboardingInviteRequestDto.java
@@ -8,10 +8,10 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import sopt.org.umbbaServer.domain.qna.model.OnboardingAnswer;
 import sopt.org.umbbaServer.domain.user.controller.dto.request.UserInfoDto;
 
 import javax.validation.Valid;
+import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import java.time.LocalTime;
 import java.util.List;
@@ -34,5 +34,6 @@ public class OnboardingInviteRequestDto {
     @JsonFormat(pattern = "kk:mm")
     private LocalTime pushTime;
 
-    private List<OnboardingAnswer> onboardingAnswerList;
+    @NotEmpty // TODO 여기서 걸러지게 만들어야함
+    private List<String> onboardingAnswerList;
 }

--- a/src/main/java/sopt/org/umbbaServer/domain/parentchild/controller/dto/request/OnboardingReceiveRequestDto.java
+++ b/src/main/java/sopt/org/umbbaServer/domain/parentchild/controller/dto/request/OnboardingReceiveRequestDto.java
@@ -5,11 +5,10 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import sopt.org.umbbaServer.domain.qna.model.OnboardingAnswer;
 import sopt.org.umbbaServer.domain.user.controller.dto.request.UserInfoDto;
 
 import javax.validation.Valid;
+import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import java.util.List;
 
@@ -18,12 +17,10 @@ import java.util.List;
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class OnboardingReceiveRequestDto {
 
-    @NonNull
-    private Long parentChildId;
-
     @NotNull
     @Valid
     private UserInfoDto userInfo;
 
-    private List<OnboardingAnswer> onboardingAnswerList;
+    @NotEmpty
+    private List<String> onboardingAnswerList;
 }

--- a/src/main/java/sopt/org/umbbaServer/domain/parentchild/controller/dto/response/OnboardingInviteResponseDto.java
+++ b/src/main/java/sopt/org/umbbaServer/domain/parentchild/controller/dto/response/OnboardingInviteResponseDto.java
@@ -1,5 +1,6 @@
 package sopt.org.umbbaServer.domain.parentchild.controller.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
@@ -21,6 +22,7 @@ public class OnboardingInviteResponseDto {
 
     private String parentchildRelation;
 
+    @JsonFormat(pattern = "kk:mm")
     private LocalTime pushTime;
 
     private String inviteCode;

--- a/src/main/java/sopt/org/umbbaServer/domain/parentchild/controller/dto/response/OnboardingReceiveResponseDto.java
+++ b/src/main/java/sopt/org/umbbaServer/domain/parentchild/controller/dto/response/OnboardingReceiveResponseDto.java
@@ -1,5 +1,6 @@
 package sopt.org.umbbaServer.domain.parentchild.controller.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
@@ -20,6 +21,7 @@ public class OnboardingReceiveResponseDto {
 
     private InviteResultResponseDto parentchildInfo;
 
+    @JsonFormat(pattern = "kk:mm")
     private LocalTime pushTime;
 
     public static OnboardingReceiveResponseDto of(Parentchild parentchild, User user, List<User> parentChildUsers) {

--- a/src/main/java/sopt/org/umbbaServer/domain/parentchild/dao/ParentchildDao.java
+++ b/src/main/java/sopt/org/umbbaServer/domain/parentchild/dao/ParentchildDao.java
@@ -28,6 +28,7 @@ public class ParentchildDao {
                     .setParameter("id", userId)
                     .getSingleResult();
             return Optional.ofNullable(parentchild);
+
         } catch (NoResultException e) {
             return Optional.empty();
         }

--- a/src/main/java/sopt/org/umbbaServer/domain/parentchild/model/Parentchild.java
+++ b/src/main/java/sopt/org/umbbaServer/domain/parentchild/model/Parentchild.java
@@ -56,6 +56,10 @@ public class Parentchild extends AuditingTimeEntity {
     @Column(nullable = false)
     private LocalTime pushTime;  // default: 오후 11시(클라이언트)
 
+    public void initQnA() {
+        qnaList = new ArrayList<>();
+    }
+
     public void addQnA(QnA qnA) {
         qnaList.add(qnA);
     }

--- a/src/main/java/sopt/org/umbbaServer/domain/parentchild/service/ParentchildService.java
+++ b/src/main/java/sopt/org/umbbaServer/domain/parentchild/service/ParentchildService.java
@@ -29,10 +29,9 @@ import java.util.List;
 @Transactional(readOnly = true)
 public class ParentchildService {
 
-    private final ParentchildDao parentchildDao;
     private final ParentchildRepository parentchildRepository;
     private final UserRepository userRepository;
-    private final QnADao qnADao;
+    private final ParentchildDao parentchildDao;
 
     // [발신] 초대하는 측의 온보딩 정보 입력
     @Transactional
@@ -72,9 +71,7 @@ public class ParentchildService {
                 request.getUserInfo().getBornYear()
         );
 
-        // TODO 추가 질문 답변 저장
-        Parentchild parentchild = getParentchildById(request.getParentChildId());
-
+        Parentchild parentchild = getParentchildByUserId(userId);
 //        parentchild.updateInfo();
         List<User> parentChildUsers = getParentChildUsers(parentchild);
 
@@ -153,7 +150,7 @@ public class ParentchildService {
         log.info("성립된 부모자식: {} X {}, 관계: {}", parentChildUsers.get(0).getUsername(), parentChildUsers.get(1).getUsername(), newMatchRelation.getRelation());
 
         // 부모자식 관계에 대한 예외처리
-        if (parentChildUsers.isEmpty() || parentChildUsers == null) {
+        if (parentChildUsers.isEmpty()) {
             throw new CustomException(ErrorType.NOT_EXIST_PARENT_CHILD_USER);
         }
 
@@ -167,18 +164,18 @@ public class ParentchildService {
 
     }
 
+    private Parentchild getParentchildByUserId(Long userId) {
 
-    private Parentchild getParentchildById(Long parentchildId) {
-        return parentchildRepository.findById(parentchildId).orElseThrow(
-                () -> new CustomException(ErrorType.NOT_EXIST_PARENT_CHILD_RELATION)
+        return parentchildDao.findByUserId(userId).orElseThrow(
+                () -> new CustomException(ErrorType.USER_HAVE_NO_PARENTCHILD)
         );
     }
 
     private User getUserById(Long userId) {
-        User user = userRepository.findById(userId).orElseThrow(
+
+        return userRepository.findById(userId).orElseThrow(
                 () -> new CustomException(ErrorType.INVALID_USER)
         );
-        return user;
     }
 
 }

--- a/src/main/java/sopt/org/umbbaServer/domain/qna/controller/dto/request/TodayAnswerRequestDto.java
+++ b/src/main/java/sopt/org/umbbaServer/domain/qna/controller/dto/request/TodayAnswerRequestDto.java
@@ -1,5 +1,7 @@
 package sopt.org.umbbaServer.domain.qna.controller.dto.request;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -8,6 +10,7 @@ import javax.validation.constraints.NotBlank;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class TodayAnswerRequestDto {
 
     @NotBlank // null, "", " "을 모두 허용하지 X

--- a/src/main/java/sopt/org/umbbaServer/domain/qna/controller/dto/response/QnAListResponseDto.java
+++ b/src/main/java/sopt/org/umbbaServer/domain/qna/controller/dto/response/QnAListResponseDto.java
@@ -12,5 +12,5 @@ public class QnAListResponseDto {
 
     private Long qnaId;
     private Integer index;
-    private String question;
+    private String topic;
 }

--- a/src/main/java/sopt/org/umbbaServer/domain/qna/model/OnboardingAnswer.java
+++ b/src/main/java/sopt/org/umbbaServer/domain/qna/model/OnboardingAnswer.java
@@ -3,6 +3,8 @@ package sopt.org.umbbaServer.domain.qna.model;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import sopt.org.umbbaServer.global.exception.CustomException;
+import sopt.org.umbbaServer.global.exception.ErrorType;
 
 @Getter
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
@@ -10,7 +12,17 @@ public enum OnboardingAnswer {
 
     YES("응"),
     NO("아니"),
-    SKIP("잘 모르겠어");
+    SKIP("애매해");
 
     private final String value;
+
+    public static OnboardingAnswer of(String value) {
+        for (OnboardingAnswer answer : OnboardingAnswer.values()) {
+            if (answer.getValue().equals(value)) {
+                return answer;
+            }
+        }
+        throw new CustomException(ErrorType.INVALID_ONBOARDING_ANSWER);
+    }
+
 }

--- a/src/main/java/sopt/org/umbbaServer/domain/qna/service/QnAService.java
+++ b/src/main/java/sopt/org/umbbaServer/domain/qna/service/QnAService.java
@@ -90,11 +90,10 @@ public class QnAService {
         return qnaList.stream()
                 .filter(qna -> Objects.equals(qna.getQuestion().getSection().getSectionId(), sectionId))
                 .map(qna -> {
-                    String question = myUser.isMeChild() ? qna.getQuestion().getChildQuestion() : qna.getQuestion().getParentQuestion();
                     return QnAListResponseDto.builder()
                             .qnaId(qna.getId())
                             .index(qnaList.indexOf(qna) + 1)
-                            .question(question)
+                            .topic(qna.getQuestion().getTopic())
                             .build();
                 })
                 .collect(Collectors.toList());

--- a/src/main/java/sopt/org/umbbaServer/domain/qna/service/QnAService.java
+++ b/src/main/java/sopt/org/umbbaServer/domain/qna/service/QnAService.java
@@ -21,6 +21,7 @@ import sopt.org.umbbaServer.domain.user.social.SocialPlatform;
 import sopt.org.umbbaServer.global.exception.CustomException;
 import sopt.org.umbbaServer.global.exception.ErrorType;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -110,9 +111,14 @@ public class QnAService {
     }
 
     @Transactional
-    public void filterFirstQuestion(Long userId, List<OnboardingAnswer> onboardingAnswerList) {
+    public void filterFirstQuestion(Long userId, List<String> onboardingAnswerStringList) {
 
         Parentchild parentchild = getParentchildByUserId(userId);
+
+        // String을 Enum으로 변경
+        List<OnboardingAnswer> onboardingAnswerList = onboardingAnswerStringList.stream()
+                .map(OnboardingAnswer::of)
+                .collect(Collectors.toList());
 
         if (getUserById(userId).isMeChild()) {
             parentchild.changeChildOnboardingAnswerList(onboardingAnswerList);
@@ -133,9 +139,14 @@ public class QnAService {
     }
 
     @Transactional
-    public void filterAllQuestion(Long userId, List<OnboardingAnswer> onboardingAnswerList) {
+    public void filterAllQuestion(Long userId, List<String> onboardingAnswerStringList) {
 
         Parentchild parentchild = getParentchildByUserId(userId);
+
+        // String을 Enum으로 변경
+        List<OnboardingAnswer> onboardingAnswerList = onboardingAnswerStringList.stream()
+                .map(OnboardingAnswer::of)
+                .collect(Collectors.toList());
 
         if (getUserById(userId).isMeChild()) {
             parentchild.changeChildOnboardingAnswerList(onboardingAnswerList);
@@ -146,7 +157,9 @@ public class QnAService {
         List<OnboardingAnswer> childList = parentchild.getChildOnboardingAnswerList();
         List<OnboardingAnswer> parentList = parentchild.getParentOnboardingAnswerList();
 
+        // 질문 그룹을 선택
         QuestionGroup selectedGroup = selectGroup(childList, parentList);
+        System.out.println("선택된 그룹: " + selectedGroup);
 
         for (QuestionSection section : QuestionSection.values()) {
             if (section == YOUNG) continue;

--- a/src/main/java/sopt/org/umbbaServer/domain/qna/service/QnAService.java
+++ b/src/main/java/sopt/org/umbbaServer/domain/qna/service/QnAService.java
@@ -128,6 +128,7 @@ public class QnAService {
                 .build();
         qnARepository.save(newQnA);
 
+        parentchild.initQnA();
         parentchild.addQnA(newQnA);
     }
 
@@ -182,8 +183,10 @@ public class QnAService {
     }
 
     private Parentchild getParentchildByUserId(Long userId) {
-        return parentchildDao.findByUserId(userId)
-                .orElseThrow(() -> new CustomException(ErrorType.USER_HAVE_NO_PARENTCHILD));
+
+        return parentchildDao.findByUserId(userId).orElseThrow(
+                () -> new CustomException(ErrorType.USER_HAVE_NO_PARENTCHILD)
+        );
     }
 
     private List<QnA> getQnAListByParentchild(Parentchild parentchild) {

--- a/src/main/java/sopt/org/umbbaServer/domain/user/controller/dto/request/RefreshRequestDto.java
+++ b/src/main/java/sopt/org/umbbaServer/domain/user/controller/dto/request/RefreshRequestDto.java
@@ -1,11 +1,14 @@
 package sopt.org.umbbaServer.domain.user.controller.dto.request;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class RefreshRequestDto {
 
     private Long userId;

--- a/src/main/java/sopt/org/umbbaServer/domain/user/controller/dto/request/SocialLoginRequestDto.java
+++ b/src/main/java/sopt/org/umbbaServer/domain/user/controller/dto/request/SocialLoginRequestDto.java
@@ -1,5 +1,7 @@
 package sopt.org.umbbaServer.domain.user.controller.dto.request;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -7,6 +9,7 @@ import sopt.org.umbbaServer.domain.user.social.SocialPlatform;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class SocialLoginRequestDto {
 
     private SocialPlatform socialPlatform;

--- a/src/main/java/sopt/org/umbbaServer/domain/user/service/AuthService.java
+++ b/src/main/java/sopt/org/umbbaServer/domain/user/service/AuthService.java
@@ -110,7 +110,7 @@ public class AuthService {
         return userRepository.existsBySocialPlatformAndSocialId(socialPlatform, socialId);
     }
 
-    private String login(SocialPlatform socialPlatform, String socialAccessToken) throws NoSuchAlgorithmException, InvalidKeySpecException {
+    private String login(SocialPlatform socialPlatform, String socialAccessToken) {
 
             try {
                 switch (socialPlatform.toString()) {

--- a/src/main/java/sopt/org/umbbaServer/global/exception/ErrorType.java
+++ b/src/main/java/sopt/org/umbbaServer/global/exception/ErrorType.java
@@ -17,6 +17,7 @@ public enum ErrorType {
     HEADER_REQUEST_MISSING_EXCEPTION(HttpStatus.BAD_REQUEST, "요청에 필요한 헤더값이 존재하지 않습니다."),
     VALIDATION_WRONG_ENUM_EXCEPTION(HttpStatus.BAD_REQUEST, "허용되지 않는 문자열이 입력되었습니다."),
     INVALID_SOCIAL_PLATFORM(HttpStatus.BAD_REQUEST, "유효하지 않은 소셜 플랫폼입니다."),
+    INVALID_ONBOARDING_ANSWER(HttpStatus.BAD_REQUEST, "유효하지 않은 선택질문 응답값입니다."),
 
     // ParentChild - Onboarding
     INVALID_PARENT_CHILD_RELATION_INFO(HttpStatus.BAD_REQUEST, "부모자식 관계를 정의할 수 없는 요청값입니다."),


### PR DESCRIPTION
## 📌 관련 이슈
closed #43

## ✨ 어떤 이유로 변경된 내용인지
- DB에 live_together 필드가 남아 있는 것 해결
- 푸시 알림 시간이 "23:00:00" 형식으로 리턴되는 것 "23:00"으로 리턴되게 수정
- YES, NO가 아니라 응, 아니로 선택질문 답변 받도록 수정
- 온보딩 정보 입력 (초대받는 측) API에서 parentchild_id 빠지게 변경
- API 명세서에 수정사항 반영
- snake_case로만 받아지는거 수정
- 과거의 문답 리스트 조회하기 질문이 아니라 주제 보여주는걸로 변경

## 🙏 검토 혹은 리뷰어에게 남기고 싶은 말
