### PR TITLE
[FEAT] 초대장 조회 API로 로직 분리

### DIFF
--- a/src/main/java/sopt/org/umbbaServer/domain/qna/controller/QnAController.java
+++ b/src/main/java/sopt/org/umbbaServer/domain/qna/controller/QnAController.java
@@ -66,7 +66,7 @@ public class QnAController {
         return ApiResponse.success(SuccessType.GET_MAIN_HOME_SUCCESS, qnAService.getMainInfo(JwtProvider.getUserFromPrincial(principal)));
     }
 
-    @GetMapping("/home/invite")
+    @GetMapping("/home/case")
     public ApiResponse<GetInvitationResponseDto> invitation(Principal principal) {
 
         return ApiResponse.success(SuccessType.GET_INVITE_CODE_SUCCESS, qnAService.getInvitation(JwtProvider.getUserFromPrincial(principal)));

--- a/src/main/java/sopt/org/umbbaServer/domain/qna/controller/QnAController.java
+++ b/src/main/java/sopt/org/umbbaServer/domain/qna/controller/QnAController.java
@@ -4,10 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import sopt.org.umbbaServer.domain.qna.controller.dto.request.TodayAnswerRequestDto;
-import sopt.org.umbbaServer.domain.qna.controller.dto.response.QnAListResponseDto;
-import sopt.org.umbbaServer.domain.qna.controller.dto.response.SingleQnAResponseDto;
-import sopt.org.umbbaServer.domain.qna.controller.dto.response.GetMainViewResponseDto;
-import sopt.org.umbbaServer.domain.qna.controller.dto.response.TodayQnAResponseDto;
+import sopt.org.umbbaServer.domain.qna.controller.dto.response.*;
 import sopt.org.umbbaServer.domain.qna.service.QnAService;
 import sopt.org.umbbaServer.global.common.dto.ApiResponse;
 import sopt.org.umbbaServer.global.config.jwt.JwtProvider;
@@ -29,6 +26,7 @@ public class QnAController {
 
         return ApiResponse.success(SuccessType.GET_TODAY_QNA_SUCCESS, qnAService.getTodayQnA(JwtProvider.getUserFromPrincial(principal)));
     }
+
 
     @PostMapping("/qna/answer")
     @ResponseStatus(HttpStatus.CREATED)
@@ -66,6 +64,12 @@ public class QnAController {
     public ApiResponse<GetMainViewResponseDto> home(Principal principal) {
 
         return ApiResponse.success(SuccessType.GET_MAIN_HOME_SUCCESS, qnAService.getMainInfo(JwtProvider.getUserFromPrincial(principal)));
+    }
+
+    @GetMapping("/home/invite")
+    public ApiResponse<GetInvitationResponseDto> invitation(Principal principal) {
+
+        return ApiResponse.success(SuccessType.GET_INVITE_CODE_SUCCESS, qnAService.getInvitation(JwtProvider.getUserFromPrincial(principal)));
     }
 
 }

--- a/src/main/java/sopt/org/umbbaServer/domain/qna/controller/dto/response/GetInvitationResponseDto.java
+++ b/src/main/java/sopt/org/umbbaServer/domain/qna/controller/dto/response/GetInvitationResponseDto.java
@@ -1,0 +1,49 @@
+package sopt.org.umbbaServer.domain.qna.controller.dto.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class GetInvitationResponseDto {
+
+    private int responseCase;  // case를 1,2,3으로 구분 (Client)
+
+    // 예외상황에 따른 필드
+    private String inviteCode;
+    private String inviteUsername;
+    private String installUrl;  // TODO Firebase Dynamic Link
+
+    private Boolean relativeUserActive;
+
+
+    // 1. 오늘의 질문을 조회한 일반적인 경우
+    public static GetInvitationResponseDto of () {
+        return GetInvitationResponseDto.builder()
+                .responseCase(1)
+                .relativeUserActive(true)
+                .build();
+    }
+
+    // 2. 아직 부모자식 관계가 매칭되지 않은 경우
+    public static GetInvitationResponseDto of (String inviteCode, String inviteUsername, String installUrl) {
+        return GetInvitationResponseDto.builder()
+                .responseCase(2)
+                .inviteCode(inviteCode)
+                .inviteUsername(inviteUsername)
+                .installUrl(installUrl)
+                .relativeUserActive(true)
+                .build();
+    }
+
+    // 3. 부모자식 중 상대 측 유저가 탈퇴한 경우
+    public static GetInvitationResponseDto of (boolean relativeUserActive) {
+        return GetInvitationResponseDto.builder()
+                .responseCase(3)
+                .relativeUserActive(relativeUserActive)
+                .build();
+    }
+}

--- a/src/main/java/sopt/org/umbbaServer/domain/qna/controller/dto/response/TodayQnAResponseDto.java
+++ b/src/main/java/sopt/org/umbbaServer/domain/qna/controller/dto/response/TodayQnAResponseDto.java
@@ -13,8 +13,6 @@ import sopt.org.umbbaServer.domain.user.model.User;
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class TodayQnAResponseDto {
 
-    private int responseCase;  // case를 1,2,3으로 구분 (Client)
-
     private Long qnaId;
     private String section;
     private String topic;
@@ -30,15 +28,7 @@ public class TodayQnAResponseDto {
     private String opponentUsername;
     private String myUsername;
 
-    // 예외상황에 따른 필드
-    private String inviteCode;
-    private String inviteUsername;
-    private String installUrl;  // TODO Firebase Dynamic Link
 
-    private Boolean relativeUserActive;
-
-
-    // 1. 오늘의 질문을 조회한 일반적인 경우
     public static TodayQnAResponseDto of(User myUser, User opponentUser, QnA todayQnA, Question todayQuestion, boolean isMeChild) {
         String opponentQuestion;
         String myQuestion;
@@ -64,7 +54,6 @@ public class TodayQnAResponseDto {
         }
 
         return TodayQnAResponseDto.builder()
-                .responseCase(1)
                 .qnaId(todayQnA.getId())
                 .section(todayQuestion.getSection().getValue())
                 .topic(todayQuestion.getTopic())
@@ -79,23 +68,6 @@ public class TodayQnAResponseDto {
                 .build();
     }
 
-    // 2. 아직 부모자식 관계가 매칭되지 않은 경우
-    public static TodayQnAResponseDto of (String inviteCode, String inviteUsername, String installUrl) {
-        return TodayQnAResponseDto.builder()
-                .responseCase(2)
-                .inviteCode(inviteCode)
-                .inviteUsername(inviteUsername)
-                .installUrl(installUrl)
-                .build();
-    }
-
-    // 3. 부모자식 중 상대 측 유저가 탈퇴한 경우
-    public static TodayQnAResponseDto of (boolean relativeUserActive) {
-        return TodayQnAResponseDto.builder()
-                .responseCase(3)
-                .relativeUserActive(relativeUserActive)
-                .build();
-    }
 }
 
 

--- a/src/main/java/sopt/org/umbbaServer/domain/qna/service/QnAService.java
+++ b/src/main/java/sopt/org/umbbaServer/domain/qna/service/QnAService.java
@@ -5,13 +5,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import sopt.org.umbbaServer.domain.parentchild.dao.ParentchildDao;
+import sopt.org.umbbaServer.domain.qna.controller.dto.response.*;
 import sopt.org.umbbaServer.domain.qna.model.*;
 import sopt.org.umbbaServer.domain.parentchild.model.Parentchild;
 import sopt.org.umbbaServer.domain.qna.controller.dto.request.TodayAnswerRequestDto;
-import sopt.org.umbbaServer.domain.qna.controller.dto.response.GetMainViewResponseDto;
-import sopt.org.umbbaServer.domain.qna.controller.dto.response.QnAListResponseDto;
-import sopt.org.umbbaServer.domain.qna.controller.dto.response.SingleQnAResponseDto;
-import sopt.org.umbbaServer.domain.qna.controller.dto.response.TodayQnAResponseDto;
 import sopt.org.umbbaServer.domain.qna.dao.QnADao;
 import sopt.org.umbbaServer.domain.qna.repository.QnARepository;
 import sopt.org.umbbaServer.domain.qna.repository.QuestionRepository;
@@ -46,6 +43,18 @@ public class QnAService {
 
     public TodayQnAResponseDto getTodayQnA(Long userId) {
 
+        User myUser = getUserById(userId);
+        Parentchild parentchild = getParentchildByUser(myUser);
+        QnA todayQnA = getTodayQnAByParentchild(parentchild);
+        Question todayQuestion = todayQnA.getQuestion();
+        User opponentUser = getOpponentByParentchild(parentchild, userId);
+
+
+        return TodayQnAResponseDto.of(myUser, opponentUser, todayQnA, todayQuestion, myUser.isMeChild());
+    }
+
+    public GetInvitationResponseDto getInvitation(Long userId) {
+
         Optional<User> matchUser = parentchildDao.findMatchUserByUserId(userId);
         log.info("matchUser: {} -> parentchildDao.findMatchUserByUserId()의 결과", matchUser);
 
@@ -57,14 +66,7 @@ public class QnAService {
             return withdrawUser();
         }
 
-        User myUser = getUserById(userId);
-        Parentchild parentchild = getParentchildByUser(myUser);
-        QnA todayQnA = getTodayQnAByParentchild(parentchild);
-        Question todayQuestion = todayQnA.getQuestion();
-        User opponentUser = getOpponentByParentchild(parentchild, userId);
-
-
-        return TodayQnAResponseDto.of(myUser, opponentUser, todayQnA, todayQuestion, myUser.isMeChild());
+        return GetInvitationResponseDto.of();
     }
 
     @Transactional
@@ -273,17 +275,17 @@ public class QnAService {
         return GetMainViewResponseDto.of(lastQna, qnAList.size());
     }
 
-    private TodayQnAResponseDto invitation(Long userId) {
+    private GetInvitationResponseDto invitation(Long userId) {
 
         User user = getUserById(userId);
         Parentchild parentchild = parentchildDao.findByUserId(userId).orElseThrow(
                 () -> new CustomException(ErrorType.USER_HAVE_NO_PARENTCHILD)
         );
 
-        return TodayQnAResponseDto.of(parentchild.getInviteCode(), user.getUsername(), "url");  // TODO url 설정 필요 (Firebase)
+        return GetInvitationResponseDto.of(parentchild.getInviteCode(), user.getUsername(), "url");  // TODO url 설정 필요 (Firebase)
     }
 
-    private TodayQnAResponseDto withdrawUser() {
-        return TodayQnAResponseDto.of(false);
+    private GetInvitationResponseDto withdrawUser() {
+        return GetInvitationResponseDto.of(false);
     }
 }


### PR DESCRIPTION
<!-- - 
❗️ PR 제목은 아래의 형식을 맞춰주세요 
- [FEAT] : 기능 추가
- [FIX] : 에러 수정, 버그 수정
- [CHORE] : gradle 세팅, 위의 것 이외에 거의 모든 것
- [DOCS] : README, 문서
- [REFACTOR] : 코드 리펙토링 (기능 변경 없이 코드만 수정할 때)
- [MODIFY] : 코드 수정 (기능의 변화가 있을 때)
-->

## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
close #45 

## ✨ 어떤 이유로 변경된 내용인지
<!-- 어떤 기능을 만들기 위한 내용인지 적어주세요 -->
<!-- 그게 아닌 경우에는 어떤 문제를 해결하기 위한 것인지 적어주세요 -->
- 메인 홈 관련 API로 로직 분리
- 기존 최근 일일문답 조회 API의 메서드 이동
- Response DTO 추가 생성하여 분리

## 🙏 검토 혹은 리뷰어에게 남기고 싶은 말
