### PR TITLE
[FIX] hasAlarm 필드 다시 삭제 (서버에서 보관 필요 없으므로)

### DIFF
--- a/src/main/java/sopt/org/umbbaServer/domain/user/model/User.java
+++ b/src/main/java/sopt/org/umbbaServer/domain/user/model/User.java
@@ -61,9 +61,6 @@ public class User extends AuditingTimeEntity {
     @Column(nullable = false)
     private String fcmToken;  // registration+token
 
-    @Column(nullable = false)
-    private boolean hasAlarm;
-
     public void updateFcmToken(String fcmToken) {
         this.fcmToken = fcmToken;
     }

--- a/src/main/java/sopt/org/umbbaServer/domain/user/service/AuthService.java
+++ b/src/main/java/sopt/org/umbbaServer/domain/user/service/AuthService.java
@@ -48,7 +48,6 @@ public class AuthService {
                     .socialId(socialId)
                     .isMeChild(true)
                     .isMatchFinish(false)
-                    .hasAlarm(false)
                     .fcmToken(request.getFcmToken())
                     .build();
 


### PR DESCRIPTION
## 📌 관련 이슈
#55

## ✨ 어떤 이유로 변경된 내용인지
- hasAlarm 필드 다시 삭제 (서버에서 보관 필요 없으므로)

## 🙏 검토 혹은 리뷰어에게 남기고 싶은 말
- DB에도 반영하였습니다 !