### PR TITLE
[FIX] 초대 받는측이 온보딩을 안끝냈을 때 질문 답변할 수 없도록 변경

### DIFF
--- a/src/main/java/sopt/org/umbbaServer/domain/qna/service/QnAService.java
+++ b/src/main/java/sopt/org/umbbaServer/domain/qna/service/QnAService.java
@@ -59,7 +59,10 @@ public class QnAService {
         if (matchUser.isEmpty()) {
             return invitation(userId);
         }
-        if (matchUser.get().getSocialPlatform().equals(SocialPlatform.WITHDRAW)) {
+        else if (matchUser.get().getUsername() == null) {
+            return invitation(userId);
+        }
+        else if (matchUser.get().getSocialPlatform().equals(SocialPlatform.WITHDRAW)) {
             return withdrawUser();
         }
 


### PR DESCRIPTION
## 📌 관련 이슈
closed #68

## ✨ 어떤 이유로 변경된 내용인지
- 상대가 초대장만 수신하고 온보딩 안마쳤는데, 반대측 유저에서 case2가 아니라 1로 출력되는 문제 해결

## 🙏 검토 혹은 리뷰어에게 남기고 싶은 말
