### PR TITLE
[FIX] 알림 서버 따로 배포 후 발생한 짜잘한 오류 수정

### DIFF
--- a/scripts/umbba-api/deploy.sh
+++ b/scripts/umbba-api/deploy.sh
@@ -43,7 +43,11 @@ then
 else
   echo "[$NOW_TIME] kill -15 $IDLE_PID"
   kill -15 $IDLE_PID
-  sleep 10
+
+  while ps -p $IDLE_PID > /dev/null; do
+      sleep 1
+    done
+  echo "[$NOW_TIME] 애플리케이션이 정상 종료되었습니다."
 fi
 
 echo "[$NOW_TIME] $IDLE_PROFILE 배포"

--- a/scripts/umbba-notification/deploy.sh
+++ b/scripts/umbba-notification/deploy.sh
@@ -7,6 +7,10 @@ TARGET_PID=$(lsof -Fp -i TCP:${TARGET_PORT} | grep -Po 'p[0-9]+' | grep -Po '[0-
 if [ ! -z ${TARGET_PID} ]; then
   echo "[$NOW_TIME] Kill WAS running at ${TARGET_PORT}." >> /home/ubuntu/notification-server/deploy.log
   sudo kill -15 ${TARGET_PID}
+  while ps -p $TARGET_PID > /dev/null; do
+      sleep 1
+    done
+  echo "[$NOW_TIME] 애플리케이션이 정상 종료되었습니다."
 fi
 
 nohup java -jar -Duser.timezone=Asia/Seoul -Dspring.profiles.active=notification $BUILD_PATH >> /home/ubuntu/notification-server/deploy.log 2>/home/ubuntu/notification-server/deploy_err.log &

--- a/umbba-api/src/main/java/sopt/org/umbba/api/controller/advice/ControllerExceptionAdvice.java
+++ b/umbba-api/src/main/java/sopt/org/umbba/api/controller/advice/ControllerExceptionAdvice.java
@@ -106,26 +106,30 @@ public class ControllerExceptionAdvice {
 
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     @ExceptionHandler(IllegalArgumentException.class)
-    public ApiResponse<Exception> handlerIllegalArgumentException(final IllegalArgumentException e) {
+    public ApiResponse<Exception> handlerIllegalArgumentException(final IllegalArgumentException e, final HttpServletRequest request) {
+        notificationService.sendExceptionToSlack(e, request);
         return ApiResponse.error(ErrorType.INTERNAL_SERVER_ERROR, e);
     }
 
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     @ExceptionHandler(IOException.class)
-    public ApiResponse<Exception> handlerIOException(final IOException e) {
+    public ApiResponse<Exception> handlerIOException(final IOException e, final HttpServletRequest request) {
+        notificationService.sendExceptionToSlack(e, request);
         return ApiResponse.error(ErrorType.INTERNAL_SERVER_ERROR, e);
     }
 
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     @ExceptionHandler(RuntimeException.class)
-    public ApiResponse<Exception> handlerRuntimeException(final RuntimeException e) {
+    public ApiResponse<Exception> handlerRuntimeException(final RuntimeException e, final HttpServletRequest request) {
+        notificationService.sendExceptionToSlack(e, request);
         return ApiResponse.error(ErrorType.INTERNAL_SERVER_ERROR, e);
     }
 
 
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     @ExceptionHandler(IndexOutOfBoundsException.class)
-    protected ApiResponse<Exception> handlerIndexOutOfBoundsException(final IndexOutOfBoundsException e) {
+    protected ApiResponse<Exception> handlerIndexOutOfBoundsException(final IndexOutOfBoundsException e, final HttpServletRequest request) {
+        notificationService.sendExceptionToSlack(e, request);
         return ApiResponse.error(ErrorType.INDEX_OUT_OF_BOUNDS, e);
     }
 
@@ -137,43 +141,50 @@ public class ControllerExceptionAdvice {
 
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     @ExceptionHandler(NoSuchElementException.class)
-    protected ApiResponse<Exception> handlerNoSuchElementException(final NoSuchElementException e) {
+    protected ApiResponse<Exception> handlerNoSuchElementException(final NoSuchElementException e, final HttpServletRequest request) {
+        notificationService.sendExceptionToSlack(e, request);
         return ApiResponse.error(ErrorType.OPTIONAL_EMPTY, e);
     }
 
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     @ExceptionHandler(IncorrectResultSizeDataAccessException.class)
-    protected ApiResponse<Exception> handlerIncorrectResultSizeDataAccessException(final IncorrectResultSizeDataAccessException e) {
+    protected ApiResponse<Exception> handlerIncorrectResultSizeDataAccessException(final IncorrectResultSizeDataAccessException e, final HttpServletRequest request) {
+        notificationService.sendExceptionToSlack(e, request);
         return ApiResponse.error(ErrorType.NON_UNIQUE_RESULT_OF_QUERY, e);
     }
 
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     @ExceptionHandler(NestedServletException.class)
-    public ApiResponse<Exception> handlerNestedServletException(final NestedServletException e) {
+    public ApiResponse<Exception> handlerNestedServletException(final NestedServletException e, final HttpServletRequest request) {
+        notificationService.sendExceptionToSlack(e, request);
         return ApiResponse.error(ErrorType.INTERNAL_SERVLET_ERROR, e);
     }
 
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     @ExceptionHandler(InvalidDataAccessApiUsageException.class)
-    public ApiResponse<Exception> handlerInvalidDataAccessApiUsageException(final InvalidDataAccessApiUsageException e) {
+    public ApiResponse<Exception> handlerInvalidDataAccessApiUsageException(final InvalidDataAccessApiUsageException e, final HttpServletRequest request) {
+        notificationService.sendExceptionToSlack(e, request);
         return ApiResponse.error(ErrorType.NO_ENUM_TYPE, e);
     }
 
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     @ExceptionHandler(DataIntegrityViolationException.class)
-    public ApiResponse<Exception> handlerDataIntegrityViolationException(final DataIntegrityViolationException e) {
+    public ApiResponse<Exception> handlerDataIntegrityViolationException(final DataIntegrityViolationException e, final HttpServletRequest request) {
+        notificationService.sendExceptionToSlack(e, request);
         return ApiResponse.error(ErrorType.DATA_INTEGRITY_ERROR, e);
     }
 
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     @ExceptionHandler(JpaSystemException.class)
-    public ApiResponse<Exception> handlerJpaSystemException(final JpaSystemException e) {
+    public ApiResponse<Exception> handlerJpaSystemException(final JpaSystemException e, final HttpServletRequest request) {
+        notificationService.sendExceptionToSlack(e, request);
         return ApiResponse.error(ErrorType.DATABASE_ERROR, e);
     }
 
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     @ExceptionHandler(NullPointerException.class)
-    public ApiResponse<Exception> handlerNullPointerException(final NullPointerException e) {
+    public ApiResponse<Exception> handlerNullPointerException(final NullPointerException e, final HttpServletRequest request) {
+        notificationService.sendExceptionToSlack(e, request);
         return ApiResponse.error(ErrorType.NULL_POINTER_ERROR, e);
     }
 

--- a/umbba-notification/src/main/java/sopt/org/umbba/notification/config/GracefulShutdown.java
+++ b/umbba-notification/src/main/java/sopt/org/umbba/notification/config/GracefulShutdown.java
@@ -1,0 +1,68 @@
+package sopt.org.umbba.notification.config;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.BeanFactoryAware;
+import org.springframework.beans.factory.support.DefaultSingletonBeanRegistry;
+import org.springframework.cloud.aws.messaging.listener.SimpleMessageListenerContainer;
+import org.springframework.context.SmartLifecycle;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class GracefulShutdown implements SmartLifecycle, BeanFactoryAware {
+    private final Map<String, SimpleMessageListenerContainer> messageListenerContainers;
+
+    private boolean isRunning;
+    private DefaultSingletonBeanRegistry beanFactory;
+
+
+    @Override
+    public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
+        this.beanFactory = (DefaultSingletonBeanRegistry) beanFactory;
+    }
+
+    @Override
+    public boolean isAutoStartup() {
+        return true;
+    }
+
+    @Override
+    public void stop(Runnable callback) {
+        stop();
+        callback.run();
+    }
+
+    @Override
+    public void start() {
+        this.isRunning = true;
+    }
+
+    @Override
+    public void stop() {
+        stopSqsListeners();
+        this.isRunning = false;
+        log.info("[GracefulShutdown 완료]");
+    }
+
+    private void stopSqsListeners() {
+        this.messageListenerContainers.keySet().forEach(beanName -> beanFactory.destroySingleton(beanName));
+    }
+
+
+    @Override
+    public boolean isRunning() {
+        return this.isRunning;
+    }
+
+    @Override
+    public int getPhase() {
+        return Integer.MAX_VALUE; // 명시적으로 PHASE 설정
+    }
+
+}

--- a/umbba-notification/src/main/java/sopt/org/umbba/notification/service/fcm/FCMService.java
+++ b/umbba-notification/src/main/java/sopt/org/umbba/notification/service/fcm/FCMService.java
@@ -227,7 +227,6 @@ public class FCMService {
                             multipleSendByToken(FCMPushRequestDto.sendTodayQna(
                                     todayQnA.getQuestion().getSection().getValue(),
                                     todayQnA.getQuestion().getTopic()), parentchild.getId());
-                            multipleSendByToken(FCMPushRequestDto.sendTodayQna("술이슈", "새벽4시 술 먹을시간"), 3L);
                         }
                     }
                 }


### PR DESCRIPTION
## 📌 관련 이슈
  #95

## ✨ 어떤 이유로 변경된 내용인지
- Parentchild 아이디 3번에 술이슈 보내지는 코드 수정
- SQS Listener 사용하는 측에 Graceful Shutdown 도입
- 운영서버에서는 Hikari Pool 로그 안보이게 변경
- ControllerExceptionAdvice의 500 에러들에서 모두 슬랙 메시지를 보내도록 수정
- CD 스크립트에서 반복문을 돌며 프로세스가 종료될때까지 sleep 하도록 수정

## 🙏 검토 혹은 리뷰어에게 남기고 싶은 말
