### PR TITLE
[HOTFIX] API가 중복 호출되어 QNA 리스트가 7개를 넘어가는 오류 해결

### DIFF
--- a/umbba-common/src/main/java/sopt/org/umbba/common/exception/ErrorType.java
+++ b/umbba-common/src/main/java/sopt/org/umbba/common/exception/ErrorType.java
@@ -31,6 +31,7 @@ public enum ErrorType {
     INVALID_PARENT_CHILD_RELATION(HttpStatus.BAD_REQUEST, "유효하지 않는 부모자식 관계입니다."),
     NOT_MATCH_PARENT_CHILD_RELATION(HttpStatus.BAD_REQUEST, "아직 부모자식 관계 매칭이 이루어지지 않았습니다."),
     ALREADY_EXISTS_PARENT_CHILD_USER(HttpStatus.BAD_REQUEST, "이미 해당 유저의 부모자식 관계가 존재합니다."),
+    ALREADY_QNA_LIST_FULL(HttpStatus.BAD_REQUEST, "이미 QNA 리스트가 가득 찼습니다"),
 
 
     /**

--- a/umbba-domain/src/main/java/sopt/org/umbba/domain/domain/parentchild/Parentchild.java
+++ b/umbba-domain/src/main/java/sopt/org/umbba/domain/domain/parentchild/Parentchild.java
@@ -2,6 +2,8 @@ package sopt.org.umbba.domain.domain.parentchild;
 
 import lombok.*;
 import lombok.extern.slf4j.Slf4j;
+import sopt.org.umbba.common.exception.ErrorType;
+import sopt.org.umbba.common.exception.model.CustomException;
 import sopt.org.umbba.domain.domain.common.AuditingTimeEntity;
 import sopt.org.umbba.domain.domain.qna.OnboardingAnswer;
 import sopt.org.umbba.domain.domain.qna.QnA;
@@ -75,6 +77,9 @@ public class Parentchild extends AuditingTimeEntity {
     }
 
     public void addQnA(QnA qnA) {
+        if (qnaList.size() >= 7) {
+            throw new CustomException(ErrorType.ALREADY_QNA_LIST_FULL);
+        }
         qnaList.add(qnA);
     }
 


### PR DESCRIPTION
## 📌 관련 이슈

## ✨ 어떤 이유로 변경된 내용인지
- 간혹 온보딩 끝나는 측에서 버튼을 2번 누르는 바람에 API가 2번 호출되는 경우 오류 발생
- QNA 리스트의 크기가 1+6개가 아닌, 1+6+6개가 되기 때문에 이 부분을 에러 핸들링 하는 것이 필요하다고 판단

## 🙏 검토 혹은 리뷰어에게 남기고 싶은 말
- 아라가 매칭 해달라고 해서, 테스트 해보다가 찾은 오류여서 바로 해결합니닷!