### PR TITLE
[FEAT] Soft Delete 기능 구현 + 과거 문답 리스트 조회 로직 수정

### DIFF
--- a/umbba-api/src/main/java/sopt/org/umbba/api/service/qna/QnAService.java
+++ b/umbba-api/src/main/java/sopt/org/umbba/api/service/qna/QnAService.java
@@ -114,8 +114,14 @@ public class QnAService {
         Parentchild parentchild = getParentchildByUser(myUser);
         List<QnA> qnaList = getQnAListByParentchild(parentchild);
 
+        QnA todayQnA = getTodayQnAByParentchild(parentchild);
+        int doneIndex = parentchild.getCount() - 1;
+        if (todayQnA.isChildAnswer() && todayQnA.isParentAnswer()) {
+            doneIndex += 1;
+        }
+
         return qnaList.stream()
-                .limit(parentchild.getCount() - 1)  // index까지만 요소를 처리
+                .limit(doneIndex)  // 현재 답변 완료된 index까지 보이도록
                 .filter(qna -> Objects.equals(qna.getQuestion().getSection().getSectionId(), sectionId))
                 .map(qna -> {
                     return QnAListResponseDto.builder()

--- a/umbba-api/src/main/java/sopt/org/umbba/api/service/user/AuthService.java
+++ b/umbba-api/src/main/java/sopt/org/umbba/api/service/user/AuthService.java
@@ -109,7 +109,15 @@ public class AuthService {
 
         Parentchild parentChild = user.getParentChild();
         List<User> findUsers = userRepository.findUserByParentChild(parentChild);
-        if (findUsers.size() == 0) {
+        boolean allUsersDeleted = true;
+
+        for (User findUser : findUsers) {
+            if (!findUser.getDeleted()) {
+                allUsersDeleted = false;
+                break; // 하나라도 deleted가 false인 경우 반복문 종료
+            }
+        }
+        if (allUsersDeleted) {
             parentchildRepository.deleteById(parentChild.getId());
             parentChild.getQnaList().forEach(qna -> qnARepository.deleteById(qna.getId()));
         }

--- a/umbba-domain/src/main/java/sopt/org/umbba/domain/domain/parentchild/Parentchild.java
+++ b/umbba-domain/src/main/java/sopt/org/umbba/domain/domain/parentchild/Parentchild.java
@@ -2,6 +2,8 @@ package sopt.org.umbba.domain.domain.parentchild;
 
 import lombok.*;
 import lombok.extern.slf4j.Slf4j;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 import sopt.org.umbba.common.exception.ErrorType;
 import sopt.org.umbba.common.exception.model.CustomException;
 import sopt.org.umbba.domain.domain.common.AuditingTimeEntity;
@@ -19,6 +21,8 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
+@SQLDelete(sql = "UPDATE parentchild SET deleted=true WHERE parentchild_id=?")
+@Where(clause = "deleted=false")
 public class Parentchild extends AuditingTimeEntity {
 
     @Id
@@ -71,6 +75,8 @@ public class Parentchild extends AuditingTimeEntity {
 
     @Column(nullable = false)
     private LocalTime pushTime;  // default: 오후 11시(클라이언트)
+
+    private boolean deleted = Boolean.FALSE;
 
     public void initQnA() {
         qnaList = new ArrayList<>();

--- a/umbba-domain/src/main/java/sopt/org/umbba/domain/domain/parentchild/repository/ParentchildRepository.java
+++ b/umbba-domain/src/main/java/sopt/org/umbba/domain/domain/parentchild/repository/ParentchildRepository.java
@@ -17,8 +17,8 @@ public interface ParentchildRepository extends Repository<Parentchild, Long> {
 
     List<Parentchild> findAll();
 
-
     // UPDATE
 
     // DELETE
+    void deleteById(Long id);
 }

--- a/umbba-domain/src/main/java/sopt/org/umbba/domain/domain/qna/QnA.java
+++ b/umbba-domain/src/main/java/sopt/org/umbba/domain/domain/qna/QnA.java
@@ -1,6 +1,8 @@
 package sopt.org.umbba.domain.domain.qna;
 
 import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 import sopt.org.umbba.domain.domain.common.AuditingTimeEntity;
 
 import javax.persistence.*;
@@ -10,6 +12,8 @@ import javax.persistence.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
+@SQLDelete(sql = "UPDATE qna SET deleted=true WHERE qna_id=?")
+@Where(clause = "deleted=false")
 public class QnA extends AuditingTimeEntity {
 
     @Id
@@ -31,6 +35,7 @@ public class QnA extends AuditingTimeEntity {
     @Column(nullable = false)
     private boolean isChildAnswer;
 
+    private boolean deleted = Boolean.FALSE;
 
     public boolean isParentAnswer() {
         return isParentAnswer;

--- a/umbba-domain/src/main/java/sopt/org/umbba/domain/domain/qna/repository/QnARepository.java
+++ b/umbba-domain/src/main/java/sopt/org/umbba/domain/domain/qna/repository/QnARepository.java
@@ -10,4 +10,6 @@ public interface QnARepository extends Repository<QnA, Long> {
     void save(QnA qnA);
 
     Optional<QnA> findQnAById(Long id);
+
+    void deleteById(Long id);
 }

--- a/umbba-domain/src/main/java/sopt/org/umbba/domain/domain/user/User.java
+++ b/umbba-domain/src/main/java/sopt/org/umbba/domain/domain/user/User.java
@@ -2,6 +2,8 @@ package sopt.org.umbba.domain.domain.user;
 
 import lombok.*;
 import lombok.extern.slf4j.Slf4j;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 import sopt.org.umbba.domain.domain.common.AuditingTimeEntity;
 import sopt.org.umbba.domain.domain.parentchild.Parentchild;
 
@@ -15,6 +17,8 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
+@SQLDelete(sql = "UPDATE user SET deleted=true WHERE user_id=?")
+@Where(clause = "deleted=false")
 public class User extends AuditingTimeEntity {
 
     @Id
@@ -82,7 +86,8 @@ public class User extends AuditingTimeEntity {
     private String socialAccessToken;
 
 //    private String socialRefreshToken;
-    //
+
+    private boolean deleted = Boolean.FALSE;
 
     // 로그인 새롭게 할 때마다 해당 필드들 업데이트
     public void updateSocialInfo(String socialNickname, String socialProfileImage, String socialAccessToken/*, String socialRefreshToken*/) {

--- a/umbba-domain/src/main/java/sopt/org/umbba/domain/domain/user/User.java
+++ b/umbba-domain/src/main/java/sopt/org/umbba/domain/domain/user/User.java
@@ -89,6 +89,10 @@ public class User extends AuditingTimeEntity {
 
     private boolean deleted = Boolean.FALSE;
 
+    public boolean getDeleted() {
+        return deleted;
+    }
+
     // 로그인 새롭게 할 때마다 해당 필드들 업데이트
     public void updateSocialInfo(String socialNickname, String socialProfileImage, String socialAccessToken/*, String socialRefreshToken*/) {
         this.socialNickname = socialNickname;

--- a/umbba-domain/src/main/java/sopt/org/umbba/domain/domain/user/User.java
+++ b/umbba-domain/src/main/java/sopt/org/umbba/domain/domain/user/User.java
@@ -89,10 +89,6 @@ public class User extends AuditingTimeEntity {
 
     private boolean deleted = Boolean.FALSE;
 
-    public boolean getDeleted() {
-        return deleted;
-    }
-
     // 로그인 새롭게 할 때마다 해당 필드들 업데이트
     public void updateSocialInfo(String socialNickname, String socialProfileImage, String socialAccessToken/*, String socialRefreshToken*/) {
         this.socialNickname = socialNickname;

--- a/umbba-domain/src/main/java/sopt/org/umbba/domain/domain/user/repository/UserRepository.java
+++ b/umbba-domain/src/main/java/sopt/org/umbba/domain/domain/user/repository/UserRepository.java
@@ -25,7 +25,6 @@ public interface UserRepository extends Repository<User, Long> {
     /*@Query(value = "select user " +
             "from User user " +
             "where user.parentChild.id = :parentchild_id")*/
-    // TODO UserRepository 에서 or ParentchildRepository에서?
     List<User> findUserByParentChild(Parentchild parentchild);
 
 

--- a/umbba-domain/src/main/java/sopt/org/umbba/domain/domain/user/repository/UserRepository.java
+++ b/umbba-domain/src/main/java/sopt/org/umbba/domain/domain/user/repository/UserRepository.java
@@ -19,6 +19,8 @@ public interface UserRepository extends Repository<User, Long> {
     Optional<User> findBySocialPlatformAndSocialId(SocialPlatform socialPlatform, String socialId);
     Optional<User> findByFcmToken(String fcmToken);
 
+    // DELETE
+    void deleteById(Long id);
 
     /*@Query(value = "select user " +
             "from User user " +


### PR DESCRIPTION
## 📌 관련 이슈
closed #105

## ✨ 어떤 이유로 변경된 내용인지
- 변경 전
두 유저가 모두 탈퇴한 경우에도 socialPlatform 필드가 WITHDRAW로 바뀌는 것 외에는 삭제 로직이 이루어지지 않았음
이에 따라 findAll() 등의 함수가 호출될 때 탈퇴된 유저까지 검색하기 때문에, 탈퇴한 유저가 누적될수록 탐색 효율이 낮아지게되는 문제 발생

- 변경 후
두 유저가 모두 탈퇴한 경우에 관련된 user 테이블, parentchild 테이블, qna 테이블을 모두 삭제하는 로직을 추가하였음
삭제할 때 hard delete가 아닌 soft delete 전략을 사용함으로써 탐색 효율은 증가시킴과 동시에, 비즈니스적으로 유용할 수 있는 정보를 DB에 보관하는 전략을 택하였음

- 한계점
한명만 탈퇴할 경우에 해당 user 테이블만이라도 soft delete 하고싶었으나, 탈퇴하지 않은 사용자가 이 user 테이블의 정보를 원하는 경우가 다수 존재하는 상황
따라서 어떤 경우에는 탈퇴한 user를 조회하도록 하고, 어떤 경우에는 탈퇴한 user는 제외하고 조회하도록 함수를 다 나눠야 했으며 WITHDRAW라는 enum에 의존적이지 않도록 바꾸기 위해 대공사가 필요했음
너무 대공사임 + 대공사인데에 비해 얻을 수 있는 효용은 크지 않음 -> 안하기로 판단
✅ 앞으로 DB 설계시에 이러한 부분을 고려한다면 참 좋을 것 같음...

- 추가 변경점
현재 섹션별 과거의 문답리스트 조회하기 API에서 전날의 질문까지만 조회하도록 하였었음
하지만 릴리즈 후 피드백을 통해, 오늘의 질문에 부모와 자식이 둘다 답변 완료했을 경우도 포함시키도록 개선

## 🙏 검토 혹은 리뷰어에게 남기고 싶은 말
