### PR TITLE
[FIX] 리마인드 알림 예외처리

### DIFF
--- a/umbba-notification/src/main/java/sopt/org/umbba/notification/service/scheduler/FCMScheduler.java
+++ b/umbba-notification/src/main/java/sopt/org/umbba/notification/service/scheduler/FCMScheduler.java
@@ -42,8 +42,8 @@ public class FCMScheduler {
                 })
                 .forEach(pc -> {
                 log.info(pc.getId() + "번째 Parentchild");
-                String cronExpression = String.format("0 %s %s * * ?", pc.getPushTime().getMinute(), pc.getPushTime().getHour());
-//                String cronExpression = String.format("*/20 * * * * *");
+//                String cronExpression = String.format("0 %s %s * * ?", pc.getPushTime().getMinute(), pc.getPushTime().getHour());
+                String cronExpression = String.format("*/20 * * * * *");
                 log.info("cron: {}", cronExpression);
                 fcmService.schedulePushAlarm(cronExpression, pc.getId());
             });

--- a/umbba-notification/src/main/java/sopt/org/umbba/notification/service/scheduler/FCMScheduler.java
+++ b/umbba-notification/src/main/java/sopt/org/umbba/notification/service/scheduler/FCMScheduler.java
@@ -42,8 +42,8 @@ public class FCMScheduler {
                 })
                 .forEach(pc -> {
                 log.info(pc.getId() + "번째 Parentchild");
-//                String cronExpression = String.format("0 %s %s * * ?", pc.getPushTime().getMinute(), pc.getPushTime().getHour());
-                String cronExpression = String.format("*/20 * * * * *");
+                String cronExpression = String.format("0 %s %s * * ?", pc.getPushTime().getMinute(), pc.getPushTime().getHour());
+//                String cronExpression = String.format("*/20 * * * * *");
                 log.info("cron: {}", cronExpression);
                 fcmService.schedulePushAlarm(cronExpression, pc.getId());
             });


### PR DESCRIPTION
<!-- - 
❗️ PR 제목은 아래의 형식을 맞춰주세요 
- [FEAT] : 기능 추가
- [FIX] : 에러 수정, 버그 수정
- [CHORE] : gradle 세팅, 위의 것 이외에 거의 모든 것
- [DOCS] : README, 문서
- [REFACTOR] : 코드 리펙토링 (기능 변경 없이 코드만 수정할 때)
- [MODIFY] : 코드 수정 (기능의 변화가 있을 때)
-->

## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
close #110 

## ✨ 어떤 이유로 변경된 내용인지
<!-- 어떤 기능을 만들기 위한 내용인지 적어주세요 -->
<!-- 그게 아닌 경우에는 어떤 문제를 해결하기 위한 것인지 적어주세요 -->

다음의 상황에 리마인드 알림을 전송하지 않도록 예외처리를 추가했습니다.
- Parentchild 관계를 맺은 유저들 중 탈퇴한 유저가 있는 경우 
- 유효한 부모자식 관계가 아닌 경우 (아직 매칭 X, 유저의 parentchild가 Null인 경우 등 )

기존에는 오늘의 질문 푸시알람 전송(multipleSendByToken() 호출 직전에 위와 같은 유효성 검사를 했었는데, 그 범위를 더 늘려서 리마인드 알림 전송 시 예외까지 처리되도록 수정했습니다. 


## 🙏 검토 혹은 리뷰어에게 남기고 싶은 말
HOTFIX !!!!!
