### PR TITLE
[FEAT] 7일 이후 문답 구현

### DIFF
--- a/umbba-api/src/main/java/sopt/org/umbba/api/controller/advice/ControllerExceptionAdvice.java
+++ b/umbba-api/src/main/java/sopt/org/umbba/api/controller/advice/ControllerExceptionAdvice.java
@@ -192,11 +192,17 @@ public class ControllerExceptionAdvice {
      * CUSTOM_ERROR
      */
     @ExceptionHandler(CustomException.class)
-    protected ResponseEntity<ApiResponse> handleCustomException(CustomException e) {
+    protected ResponseEntity<ApiResponse> handleCustomException(CustomException e, final HttpServletRequest request) {
 
         log.error("CustomException occured: {}", e.getMessage(), e);
 
-        return ResponseEntity.status(e.getHttpStatus())
-                .body(ApiResponse.error(e.getErrorType(), e.getMessage()));
+        if (e.getHttpStatus() == 501) {
+            notificationService.sendExceptionToSlack(e, request);
+            return ResponseEntity.status(e.getHttpStatus())
+                    .body(ApiResponse.error(ErrorType.NEED_MORE_QUESTION));
+        } else {
+            return ResponseEntity.status(e.getHttpStatus())
+                    .body(ApiResponse.error(e.getErrorType(), e.getMessage()));
+        }
     }
 }

--- a/umbba-api/src/main/java/sopt/org/umbba/api/controller/qna/QnAController.java
+++ b/umbba-api/src/main/java/sopt/org/umbba/api/controller/qna/QnAController.java
@@ -70,6 +70,14 @@ public class QnAController {
                 qnAService.getSingleQna(JwtProvider.getUserFromPrincial(principal), qnaId));
     }
 
+    @PatchMapping("/qna/restart")
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResponse restartQna(Principal principal) {
+
+        qnAService.restartQna(JwtProvider.getUserFromPrincial(principal));
+        return ApiResponse.success(SuccessType.RESTART_QNA_SUCCESS);
+    }
+
     @GetMapping("/home")
     @ResponseStatus(HttpStatus.OK)
     public ApiResponse<GetMainViewResponseDto> home(Principal principal) {

--- a/umbba-api/src/main/java/sopt/org/umbba/api/service/qna/QnAService.java
+++ b/umbba-api/src/main/java/sopt/org/umbba/api/service/qna/QnAService.java
@@ -324,9 +324,8 @@ public class QnAService {
         log.info("getCount(): {}", parentchild.getCount());
 
         if (parentchild.getCount() == 7 && (currentQnA.isParentAnswer() && currentQnA.isChildAnswer())) {
-            return GetMainViewResponseDto.of(currentQnA, parentchild.getCount()+1);  // 유효하지 않은 8로 반환 시 엔딩이벤트
+            return GetMainViewResponseDto.of(currentQnA, -1);  // 유효하지 않은 -1로 반환 시 엔딩이벤트
         }
-
 
         return GetMainViewResponseDto.of(currentQnA, parentchild.getCount());
     }

--- a/umbba-api/src/main/java/sopt/org/umbba/api/service/qna/QnAService.java
+++ b/umbba-api/src/main/java/sopt/org/umbba/api/service/qna/QnAService.java
@@ -22,7 +22,7 @@ import javax.validation.constraints.NotNull;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import static sopt.org.umbba.common.exception.ErrorType.QUESTION_NOT_FOUND_ERROR;
+import static sopt.org.umbba.common.exception.ErrorType.NEED_MORE_QUESTION;
 import static sopt.org.umbba.domain.domain.qna.OnboardingAnswer.NO;
 import static sopt.org.umbba.domain.domain.qna.OnboardingAnswer.YES;
 import static sopt.org.umbba.domain.domain.qna.QuestionSection.*;
@@ -348,7 +348,7 @@ public class QnAService {
         // 5. 이 경우 아예 추가될 질문이 없으므로 예외 발생시킴
         List<Question> targetQuestions = questionRepository.findByTypeInAndIdNotIn(types, doneQuestionIds);
         if (targetQuestions.isEmpty()) {
-            throw new CustomException(QUESTION_NOT_FOUND_ERROR);
+            throw new CustomException(NEED_MORE_QUESTION);
         }
 
         QuestionSection section = qnaList.get(parentchild.getCount() - 1).getQuestion().getSection();

--- a/umbba-common/src/main/java/sopt/org/umbba/common/exception/ErrorType.java
+++ b/umbba-common/src/main/java/sopt/org/umbba/common/exception/ErrorType.java
@@ -81,6 +81,7 @@ public enum ErrorType {
     DATABASE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "데이터베이스 관련 에러가 발생했습니다."),
     FIREBASE_CONNECTION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "파이어베이스 서버와의 연결에 실패했습니다."),
     FAIL_TO_SEND_PUSH_ALARM(HttpStatus.INTERNAL_SERVER_ERROR, "푸시 알림 메세지 전송에 실패했습니다."),
+    NEED_MORE_QUESTION(HttpStatus.INTERNAL_SERVER_ERROR, "7일 이후에 더이상 추가될 질문이 없습니다. 질문을 추가해주세요."),
 
     // ETC
     INDEX_OUT_OF_BOUNDS(HttpStatus.INTERNAL_SERVER_ERROR, "인덱스 범위를 초과했습니다."),

--- a/umbba-common/src/main/java/sopt/org/umbba/common/exception/ErrorType.java
+++ b/umbba-common/src/main/java/sopt/org/umbba/common/exception/ErrorType.java
@@ -61,7 +61,7 @@ public enum ErrorType {
     PARENTCHILD_HAVE_NO_QNALIST(HttpStatus.NOT_FOUND, "부모자식 관계가 가지고 있는 QnA 데이터가 없습니다."),
     PARENTCHILD_HAVE_NO_OPPONENT(HttpStatus.NOT_FOUND, "부모자식 관계에 1명만 참여하고 있습니다."),
     NOT_FOUND_SECTION(HttpStatus.NOT_FOUND, "해당 아이디와 일치하는 섹션이 없습니다."),
-
+    QUESTION_NOT_FOUND_ERROR(HttpStatus.NOT_FOUND, "새로운 질문을 불러올 수 없습니다."),
 
     /**
      * About Apple (HttpStatus 고민)
@@ -82,7 +82,6 @@ public enum ErrorType {
     FIREBASE_CONNECTION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "파이어베이스 서버와의 연결에 실패했습니다."),
     FAIL_TO_SEND_PUSH_ALARM(HttpStatus.INTERNAL_SERVER_ERROR, "푸시 알림 메세지 전송에 실패했습니다."),
 
-
     // ETC
     INDEX_OUT_OF_BOUNDS(HttpStatus.INTERNAL_SERVER_ERROR, "인덱스 범위를 초과했습니다."),
     JWT_SERIALIZE(HttpStatus.INTERNAL_SERVER_ERROR, "JWT 라이브러리 직렬화에 실패했습니다."),
@@ -92,7 +91,6 @@ public enum ErrorType {
     NO_ENUM_TYPE(HttpStatus.INTERNAL_SERVER_ERROR, "해당 Enum 타입이 데이터베이스 엔티티와 매핑될 수 없습니다."),
     DATA_INTEGRITY_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "데이터 무결성 제약조건을 위반했습니다."),
     NULL_POINTER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "NULL 포인터를 참조했습니다."),
-
 
 
     ;

--- a/umbba-common/src/main/java/sopt/org/umbba/common/exception/ErrorType.java
+++ b/umbba-common/src/main/java/sopt/org/umbba/common/exception/ErrorType.java
@@ -61,7 +61,6 @@ public enum ErrorType {
     PARENTCHILD_HAVE_NO_QNALIST(HttpStatus.NOT_FOUND, "부모자식 관계가 가지고 있는 QnA 데이터가 없습니다."),
     PARENTCHILD_HAVE_NO_OPPONENT(HttpStatus.NOT_FOUND, "부모자식 관계에 1명만 참여하고 있습니다."),
     NOT_FOUND_SECTION(HttpStatus.NOT_FOUND, "해당 아이디와 일치하는 섹션이 없습니다."),
-    QUESTION_NOT_FOUND_ERROR(HttpStatus.NOT_FOUND, "새로운 질문을 불러올 수 없습니다."),
 
     /**
      * About Apple (HttpStatus 고민)
@@ -81,7 +80,6 @@ public enum ErrorType {
     DATABASE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "데이터베이스 관련 에러가 발생했습니다."),
     FIREBASE_CONNECTION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "파이어베이스 서버와의 연결에 실패했습니다."),
     FAIL_TO_SEND_PUSH_ALARM(HttpStatus.INTERNAL_SERVER_ERROR, "푸시 알림 메세지 전송에 실패했습니다."),
-    NEED_MORE_QUESTION(HttpStatus.INTERNAL_SERVER_ERROR, "7일 이후에 더이상 추가될 질문이 없습니다. 질문을 추가해주세요."),
 
     // ETC
     INDEX_OUT_OF_BOUNDS(HttpStatus.INTERNAL_SERVER_ERROR, "인덱스 범위를 초과했습니다."),
@@ -93,6 +91,10 @@ public enum ErrorType {
     DATA_INTEGRITY_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "데이터 무결성 제약조건을 위반했습니다."),
     NULL_POINTER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "NULL 포인터를 참조했습니다."),
 
+    /**
+     * 501 NOT_IMPLEMENTED
+     */
+    NEED_MORE_QUESTION(HttpStatus.NOT_IMPLEMENTED, "남은 질문이 없습니다. 질문을 추가해주세요."),
 
     ;
 

--- a/umbba-common/src/main/java/sopt/org/umbba/common/exception/SuccessType.java
+++ b/umbba-common/src/main/java/sopt/org/umbba/common/exception/SuccessType.java
@@ -26,6 +26,7 @@ public enum SuccessType {
     PUSH_ALARM_PERIODIC_SUCCESS(HttpStatus.OK, "오늘의 질문 푸시알림 활성에 성공했습니다."),
     REMIND_QUESTION_SUCCESS(HttpStatus.OK, "상대방에게 질문을 리마인드 하는 데 성공했습니다."),
     TEST_SUCCESS(HttpStatus.OK, "데모데이 테스트용 API 호출에 성공했습니다."),
+    RESTART_QNA_SUCCESS(HttpStatus.OK, "7일 이후 문답이 정상적으로 시작되었습니다."),
 
 
     /**

--- a/umbba-domain/src/main/java/sopt/org/umbba/domain/domain/parentchild/Parentchild.java
+++ b/umbba-domain/src/main/java/sopt/org/umbba/domain/domain/parentchild/Parentchild.java
@@ -38,10 +38,8 @@ public class Parentchild extends AuditingTimeEntity {
     private int count;
 
     public void addCount() {
-        if (this.count < 7) {
-            this.count += 1;
-            log.info("Parentchild - addCount() 호출: {}", this.count);
-        }
+        this.count += 1;
+        log.info("Parentchild - addCount() 호출: {}", this.count);
         // 미답변 일수 필드 0으로 초기화
         this.remindCnt = 0;
     }
@@ -87,14 +85,18 @@ public class Parentchild extends AuditingTimeEntity {
 
     private boolean deleted = Boolean.FALSE;
 
-    public void initQnA() {
+    public void initQna() {
         qnaList = new ArrayList<>();
     }
 
-    public void addQnA(QnA qnA) {
+    public void setQna(QnA qnA) {
         if (qnaList.size() >= 7) {
             throw new CustomException(ErrorType.ALREADY_QNA_LIST_FULL);
         }
+        qnaList.add(qnA);
+    }
+
+    public void addQna(QnA qnA) {
         qnaList.add(qnA);
     }
 

--- a/umbba-domain/src/main/java/sopt/org/umbba/domain/domain/qna/repository/QuestionRepository.java
+++ b/umbba-domain/src/main/java/sopt/org/umbba/domain/domain/qna/repository/QuestionRepository.java
@@ -17,6 +17,8 @@ public interface QuestionRepository extends Repository<Question, Long> {
 
     List<Question> findByType(QuestionType type);
 
+    List<Question> findByTypeInAndIdNotIn(List<QuestionType> types, List<Long> doneQuestionIds);
+
     default List<Question> findBySectionAndTypeRandom(QuestionSection section, QuestionType type, int size) {
         List<Question> matchingQuestions = findBySectionAndType(section, type);
         List<Question> selectedQuestions = new ArrayList<>();

--- a/umbba-notification/src/main/java/sopt/org/umbba/notification/service/fcm/FCMController.java
+++ b/umbba-notification/src/main/java/sopt/org/umbba/notification/service/fcm/FCMController.java
@@ -6,7 +6,7 @@ import org.springframework.web.bind.annotation.*;
 import sopt.org.umbba.common.exception.SuccessType;
 import sopt.org.umbba.common.exception.dto.ApiResponse;
 import sopt.org.umbba.common.sqs.dto.FCMPushRequestDto;
-import sopt.org.umbba.notification.service.fcm.FCMService;
+import sopt.org.umbba.notification.config.ScheduleConfig;
 import sopt.org.umbba.notification.service.scheduler.FCMScheduler;
 
 import java.io.IOException;
@@ -28,6 +28,7 @@ public class FCMController {
     @PostMapping("/qna")
     @ResponseStatus(HttpStatus.OK)
     public ApiResponse sendTopicScheduledTest() {
+        ScheduleConfig.resetScheduler();
         return ApiResponse.success(SuccessType.PUSH_ALARM_PERIODIC_SUCCESS, fcmScheduler.pushTodayQna());
     }
 

--- a/umbba-notification/src/main/java/sopt/org/umbba/notification/service/fcm/FCMService.java
+++ b/umbba-notification/src/main/java/sopt/org/umbba/notification/service/fcm/FCMService.java
@@ -46,7 +46,7 @@ import java.util.Random;
 import java.util.concurrent.ScheduledFuture;
 import java.util.stream.Collectors;
 
-import static sopt.org.umbba.common.exception.ErrorType.QUESTION_NOT_FOUND_ERROR;
+import static sopt.org.umbba.common.exception.ErrorType.NEED_MORE_QUESTION;
 import static sopt.org.umbba.domain.domain.qna.QuestionType.MAIN;
 import static sopt.org.umbba.domain.domain.qna.QuestionType.YET;
 
@@ -322,7 +322,8 @@ public class FCMService {
         // 5. 이 경우 아예 추가될 질문이 없으므로 예외 발생시킴
         List<Question> targetQuestions = questionRepository.findByTypeInAndIdNotIn(types, doneQuestionIds);
         if (targetQuestions.isEmpty()) {
-            throw new CustomException(QUESTION_NOT_FOUND_ERROR);
+            // 충실한 유저가 추가될 수 있는 질문을 모두 수행했을 경우, 기획 측에서 알 수 있도록 500 에러로 처리
+            throw new CustomException(NEED_MORE_QUESTION);
         }
 
         QuestionSection section = qnaList.get(parentchild.getCount() - 1).getQuestion().getSection();

--- a/umbba-notification/src/main/java/sopt/org/umbba/notification/service/fcm/FCMService.java
+++ b/umbba-notification/src/main/java/sopt/org/umbba/notification/service/fcm/FCMService.java
@@ -21,11 +21,15 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.DefaultTransactionDefinition;
 import sopt.org.umbba.common.exception.ErrorType;
 import sopt.org.umbba.common.exception.model.CustomException;
-import sopt.org.umbba.common.sqs.dto.PushMessage;
 import sopt.org.umbba.domain.domain.parentchild.Parentchild;
 import sopt.org.umbba.domain.domain.parentchild.dao.ParentchildDao;
 import sopt.org.umbba.domain.domain.parentchild.repository.ParentchildRepository;
 import sopt.org.umbba.domain.domain.qna.QnA;
+import sopt.org.umbba.domain.domain.qna.Question;
+import sopt.org.umbba.domain.domain.qna.QuestionSection;
+import sopt.org.umbba.domain.domain.qna.QuestionType;
+import sopt.org.umbba.domain.domain.qna.repository.QnARepository;
+import sopt.org.umbba.domain.domain.qna.repository.QuestionRepository;
 import sopt.org.umbba.domain.domain.user.SocialPlatform;
 import sopt.org.umbba.domain.domain.user.User;
 import sopt.org.umbba.domain.domain.user.repository.UserRepository;
@@ -38,7 +42,13 @@ import javax.persistence.PessimisticLockException;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Random;
 import java.util.concurrent.ScheduledFuture;
+import java.util.stream.Collectors;
+
+import static sopt.org.umbba.common.exception.ErrorType.QUESTION_NOT_FOUND_ERROR;
+import static sopt.org.umbba.domain.domain.qna.QuestionType.MAIN;
+import static sopt.org.umbba.domain.domain.qna.QuestionType.YET;
 
 /**
  * 서버에서 파이어베이스로 전송이 잘 이루어지는지 테스트하기 위한 컨트롤러
@@ -59,6 +69,8 @@ public class FCMService {
 
     private final UserRepository userRepository;
     private final ParentchildRepository parentchildRepository;
+    private final QnARepository qnARepository;
+    private final QuestionRepository questionRepository;
     private final ParentchildDao parentchildDao;
     private final ObjectMapper objectMapper;
     private final TaskScheduler taskScheduler;
@@ -184,7 +196,6 @@ public class FCMService {
 
         scheduledFuture = taskScheduler.schedule(() -> {
 
-
             try {
                 Thread.sleep(1000);
             } catch (InterruptedException e) {
@@ -247,7 +258,12 @@ public class FCMService {
                         }
 
                         // 부모와 자식 모두 답변한 경우
-                        else if (currentQnA.isParentAnswer() && currentQnA.isChildAnswer() && parentchild.getCount() < 7) {
+                        else if (currentQnA.isParentAnswer() && currentQnA.isChildAnswer() && parentchild.getCount() != 7) {
+
+                            // 8일 이후 (7일 + 엔딩페이지 API 통신으로 추가된 1일) 에는 스케줄링을 돌며 QnA 직접 추가
+                            if (parentchild.getCount() >= 8) {
+                                appendQna(parentchild);
+                            }
 
                             log.info("둘 다 답변함 다음 질문으로 ㄱ {}", parentchild.getCount());
                             parentchild.addCount();   // 오늘의 질문 UP & 리마인드 카운트 초기화
@@ -269,8 +285,6 @@ public class FCMService {
                                     todayQnA.getQuestion().getTopic()), parentchild.getId());
                         }
                     }
-
-
                 }
                 transactionManager.commit(transactionStatus);
             } catch (PessimisticLockingFailureException | PessimisticLockException e) {
@@ -294,7 +308,59 @@ public class FCMService {
         log.info("ScheduledFuture: {}", scheduledFuture);
     }
 
+    private void appendQna(Parentchild parentchild) {
+        List<QnA> qnaList = getQnAListByParentchild(parentchild);
 
+        // 1. 메인 타입과 미사용 타입에 대해서 불러오기
+        List<QuestionType> types = Arrays.asList(MAIN, YET);
+
+        // 2. 내가 이미 주고받은 질문 제외하기
+        List<Long> doneQuestionIds = qnaList.stream()
+                .map(qna -> qna.getQuestion().getId())
+                .collect(Collectors.toList());
+
+        // 5. 이 경우 아예 추가될 질문이 없으므로 예외 발생시킴
+        List<Question> targetQuestions = questionRepository.findByTypeInAndIdNotIn(types, doneQuestionIds);
+        if (targetQuestions.isEmpty()) {
+            throw new CustomException(QUESTION_NOT_FOUND_ERROR);
+        }
+
+        QuestionSection section = qnaList.get(parentchild.getCount() - 1).getQuestion().getSection();
+        List<Question> differentSectionQuestions = targetQuestions.stream()
+                .filter(question -> !question.getSection().equals(section))
+                .collect(Collectors.toList());
+
+        Random random = new Random();
+        Question randomQuestion;
+        if (!differentSectionQuestions.isEmpty()) {
+            // 3. 최근에 주고받은 질문의 section과 다른 질문들 중에서 랜덤하게 추출
+            randomQuestion = differentSectionQuestions.get(random.nextInt(differentSectionQuestions.size()));
+        } else {
+            // 4. 없다면 동일한 section의 질문 중에서라도 랜덤하게 추출
+            List<Question> equalSectionQuestions = targetQuestions.stream()
+                    .filter(question -> !question.getSection().equals(section))
+                    .collect(Collectors.toList());
+            randomQuestion = equalSectionQuestions.get(random.nextInt(equalSectionQuestions.size()));
+        }
+
+        QnA newQnA = QnA.builder()
+                .question(randomQuestion)
+                .isParentAnswer(false)
+                .isChildAnswer(false)
+                .build();
+
+        qnARepository.save(newQnA);
+        parentchild.addQna(newQnA);
+    }
+
+    private List<QnA> getQnAListByParentchild(Parentchild parentchild) {
+        List<QnA> qnaList = parentchild.getQnaList();
+        if (qnaList == null || qnaList.isEmpty()) {
+            throw new CustomException(ErrorType.PARENTCHILD_HAVE_NO_QNALIST);
+        }
+
+        return qnaList;
+    }
 
     /**
      * 사용 안하는 함수들


### PR DESCRIPTION
## 📌 관련 이슈
closed #121

## ✨ 어떤 이유로 변경된 내용인지
"엄빠도 어렸다"는 더이상 7일에 멈추는 서비스가 아닙니다.

- **지금 현재 DB에 있는 질문들의 타입**
    1. 고정 질문 -> 어린시절의 질문 1개
    2. 메인 질문 -> 큰 줄기가 되는 질문들 6개
    3. 타입 질문 -> 온보딩에서의 답변에 따라서 변경되는 질문 7개
    4. 미사용 질문 -> 아직 사용되지 않은 질문 4개 + 12개 더 추가 예정

- **7일 이후에 새롭게 추가될 때 해야하는 작업**
    1. 위 4개의 타입 중 메인 질문 + 미사용 질문만 뽑아온다
    2. 쭉 뽑아온 질문들 중에서 내가 이미 주고받은 질문은 제한다 (여기까지는 쿼리로 한방에 해결)
    3. 이전에 했던 질문과 다른 섹션 질문이 있는지 먼저 찾는다
    4. 없다면 동일한 섹션 질문이라도 넣어둔다
    6. 그것마저 없다면 멈춘다

## 🙏 검토 혹은 리뷰어에게 남기고 싶은 말
- 생각보다 복잡합니다..
- 자세한 내용은 이곳을 참고 -> https://harsh-step-7dd.notion.site/SP3-API-a1bdc3cea2bd4aa4a009490982ecdafc?pvs=4