### PR TITLE
[MODIFY] 마이페이지 추가 응답 데이터 반영

### DIFF
--- a/umbba-api/src/main/java/sopt/org/umbba/api/controller/qna/dto/response/MyUserInfoResponseDto.java
+++ b/umbba-api/src/main/java/sopt/org/umbba/api/controller/qna/dto/response/MyUserInfoResponseDto.java
@@ -2,14 +2,12 @@ package sopt.org.umbba.api.controller.qna.dto.response;
 
 import static sopt.org.umbba.domain.domain.parentchild.ParentchildRelation.*;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import lombok.Builder;
 import lombok.Getter;
 import sopt.org.umbba.domain.domain.parentchild.Parentchild;
-import sopt.org.umbba.domain.domain.parentchild.ParentchildRelation;
 import sopt.org.umbba.domain.domain.qna.QnA;
 import sopt.org.umbba.domain.domain.qna.QuestionSection;
 import sopt.org.umbba.domain.domain.user.User;
@@ -17,7 +15,6 @@ import sopt.org.umbba.domain.domain.user.User;
 @Getter
 @Builder
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public class MyUserInfoResponseDto {
 
 	private String myUsername;

--- a/umbba-api/src/main/java/sopt/org/umbba/api/controller/qna/dto/response/MyUserInfoResponseDto.java
+++ b/umbba-api/src/main/java/sopt/org/umbba/api/controller/qna/dto/response/MyUserInfoResponseDto.java
@@ -44,10 +44,14 @@ public class MyUserInfoResponseDto {
 	}
 
 	// 아직 매칭된 유저가 없는 경우
-	public static MyUserInfoResponseDto of(User myUser) {
+	public static MyUserInfoResponseDto of(User myUser, Parentchild parentchild) {
 
 		return MyUserInfoResponseDto.builder()
 			.myUsername(myUser.getUsername())
+			.myUserType(getUserType(parentchild.getRelation(), myUser.isMeChild()))
+			.opponentUserType(getUserType(parentchild.getRelation(), !myUser.isMeChild()))
+			.parentchildRelation(parentchild.getRelation().getValue())
+			.isMeChild(myUser.isMeChild())
 			.section(QuestionSection.YOUNG.getValue())
 			.matchedDate(0L)
 			.qnaCnt(0).build();

--- a/umbba-api/src/main/java/sopt/org/umbba/api/service/qna/QnAService.java
+++ b/umbba-api/src/main/java/sopt/org/umbba/api/service/qna/QnAService.java
@@ -220,7 +220,7 @@ public class QnAService {
 
         // 매칭된 상대 유저가 없는 경우
         if (opponentUserList.isEmpty()) {
-            return MyUserInfoResponseDto.of(myUser);
+            return MyUserInfoResponseDto.of(myUser, parentchild);
         }
 
         User opponentUser = getOpponentByParentchild(parentchild, userId);


### PR DESCRIPTION
<!-- - 
❗️ PR 제목은 아래의 형식을 맞춰주세요 
- [FEAT] : 기능 추가
- [FIX] : 에러 수정, 버그 수정
- [CHORE] : gradle 세팅, 위의 것 이외에 거의 모든 것
- [DOCS] : README, 문서
- [REFACTOR] : 코드 리펙토링 (기능 변경 없이 코드만 수정할 때)
- [MODIFY] : 코드 수정 (기능의 변화가 있을 때)
-->

## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
#117 

## ✨ 어떤 이유로 변경된 내용인지
<!-- 어떤 기능을 만들기 위한 내용인지 적어주세요 -->
<!-- 그게 아닌 경우에는 어떤 문제를 해결하기 위한 것인지 적어주세요 -->

#### 디자인 변경 사항에 따른 마이페이지 응답 데이터 반영
- 기존 : 매칭 전, 유저 본인의 이름 정보 외에는 null로 반환
- 변경 : 매칭 전, 상대 유저의 이름 정보 외 모두 포함하여 반환
       ex. 부모-자식 관계 유형, 유저/상대 유저 타입(아들,딸,엄마,아빠), 유저 본인의 자식 여부\\\
```json
# 매칭이 완료되기 전, 마이페이지 조회에 대한 응답 값
{
  "status": 200,
  "message": "마이페이지 내 정보 조회에 성공했습니다.",
  "data": {
    "my_username": "최영린ㄹ니",
    "my_user_type": "아들",
    "opponent_username": null,
    "opponent_user_type": "엄마",
    "parentchild_relation": "엄마와 아들 관계",
    "is_me_child": true,
    "section": "어린시절",
    "matched_date": 0,
    "qna_cnt": 0
  }
}
```

## 🙏 검토 혹은 리뷰어에게 남기고 싶은 말
