### PR TITLE
[MODIFY] 문답 튜토리얼 추가에 따른 API 변경사항 적용

### DIFF
--- a/umbba-api/src/main/java/sopt/org/umbba/api/controller/qna/QnAController.java
+++ b/umbba-api/src/main/java/sopt/org/umbba/api/controller/qna/QnAController.java
@@ -100,7 +100,7 @@ public class QnAController {
         return ApiResponse.success(SuccessType.GET_MY_USER_INFO_SUCCESS, qnAService.getUserInfo(getUserFromPrincial(principal)));
     }
 
-    @PatchMapping("/user/first")
+    @PatchMapping("/home/first")
     @ResponseStatus(HttpStatus.OK)
     public ApiResponse<FirstEntryResponseDto> firstEntry(Principal principal) {
         return ApiResponse.success(SuccessType.GET_USER_FIRST_ENTRY_SUCCESS, qnAService.updateUserFirstEntry(getUserFromPrincial(principal)));

--- a/umbba-api/src/main/java/sopt/org/umbba/api/controller/qna/QnAController.java
+++ b/umbba-api/src/main/java/sopt/org/umbba/api/controller/qna/QnAController.java
@@ -100,4 +100,10 @@ public class QnAController {
         return ApiResponse.success(SuccessType.GET_MY_USER_INFO_SUCCESS, qnAService.getUserInfo(getUserFromPrincial(principal)));
     }
 
+    @PatchMapping("/user/first")
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResponse<FirstEntryResponseDto> firstEntry(Principal principal) {
+        return ApiResponse.success(SuccessType.GET_USER_FIRST_ENTRY_SUCCESS, qnAService.updateUserFirstEntry(getUserFromPrincial(principal)));
+    }
+
 }

--- a/umbba-api/src/main/java/sopt/org/umbba/api/controller/qna/dto/response/FirstEntryResponseDto.java
+++ b/umbba-api/src/main/java/sopt/org/umbba/api/controller/qna/dto/response/FirstEntryResponseDto.java
@@ -1,0 +1,22 @@
+package sopt.org.umbba.api.controller.qna.dto.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import lombok.Builder;
+import lombok.Getter;
+import sopt.org.umbba.domain.domain.user.User;
+
+@Getter
+@Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class FirstEntryResponseDto {
+
+	private Boolean isFirstEntry;
+
+	public static FirstEntryResponseDto of(User user) {
+		return FirstEntryResponseDto.builder()
+			.isFirstEntry(user.isFirstEntry())
+			.build();
+	}
+}

--- a/umbba-api/src/main/java/sopt/org/umbba/api/controller/qna/dto/response/FirstEntryResponseDto.java
+++ b/umbba-api/src/main/java/sopt/org/umbba/api/controller/qna/dto/response/FirstEntryResponseDto.java
@@ -14,9 +14,9 @@ public class FirstEntryResponseDto {
 
 	private Boolean isFirstEntry;
 
-	public static FirstEntryResponseDto of(User user) {
+	public static FirstEntryResponseDto of(boolean isFirstEntry) {
 		return FirstEntryResponseDto.builder()
-			.isFirstEntry(user.isFirstEntry())
+			.isFirstEntry(isFirstEntry)
 			.build();
 	}
 }

--- a/umbba-api/src/main/java/sopt/org/umbba/api/controller/qna/dto/response/GetInvitationResponseDto.java
+++ b/umbba-api/src/main/java/sopt/org/umbba/api/controller/qna/dto/response/GetInvitationResponseDto.java
@@ -10,7 +10,7 @@ import lombok.Getter;
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class GetInvitationResponseDto {
 
-    private int responseCase;  // case를 1,2,3으로 구분 (Client)
+    private int responseCase;  // case를 1,2,3,4으로 구분 (Client)
 
     // 예외상황에 따른 필드
     private String inviteCode;
@@ -19,12 +19,15 @@ public class GetInvitationResponseDto {
 
     private Boolean relativeUserActive;
 
+    private Boolean isUserFirstAnswer;
+
 
     // 1. 오늘의 질문을 조회한 일반적인 경우
     public static GetInvitationResponseDto of () {
         return GetInvitationResponseDto.builder()
                 .responseCase(1)
                 .relativeUserActive(true)
+                .isUserFirstAnswer(true)
                 .build();
     }
 
@@ -36,6 +39,7 @@ public class GetInvitationResponseDto {
                 .inviteUsername(inviteUsername)
                 .installUrl(installUrl)
                 .relativeUserActive(true)
+                .isUserFirstAnswer(true)
                 .build();
     }
 
@@ -44,6 +48,16 @@ public class GetInvitationResponseDto {
         return GetInvitationResponseDto.builder()
                 .responseCase(3)
                 .relativeUserActive(relativeUserActive)
+                .isUserFirstAnswer(true)
+                .build();
+    }
+
+    // 4. 아직 첫 질문에 답변하지 않은 경우
+    public static GetInvitationResponseDto ofFirst (boolean isUserFirstAnswer) {
+        return GetInvitationResponseDto.builder()
+                .responseCase(4)
+                .relativeUserActive(true)
+                .isUserFirstAnswer(isUserFirstAnswer)
                 .build();
     }
 }

--- a/umbba-api/src/main/java/sopt/org/umbba/api/service/qna/QnAService.java
+++ b/umbba-api/src/main/java/sopt/org/umbba/api/service/qna/QnAService.java
@@ -345,6 +345,8 @@ public class QnAService {
     // 메인페이지 정보
     public GetMainViewResponseDto getMainInfo(Long userId) {
 
+        // updateUserFirstEntry(userId);
+
         Parentchild parentchild = getParentchild(userId);
 
         List<QnA> qnaList = getQnAListByParentchild(parentchild);
@@ -357,6 +359,15 @@ public class QnAService {
         }
 
         return GetMainViewResponseDto.of(currentQnA, parentchild.getCount());
+    }
+
+    @Transactional
+    public FirstEntryResponseDto updateUserFirstEntry(Long userId) {
+        User user = getUserById(userId);
+        if (user.isFirstEntry()) {
+            user.updateIsFirstEntry();
+        }
+        return FirstEntryResponseDto.of(user);
     }
 
     @Transactional

--- a/umbba-api/src/main/java/sopt/org/umbba/api/service/qna/QnAService.java
+++ b/umbba-api/src/main/java/sopt/org/umbba/api/service/qna/QnAService.java
@@ -378,10 +378,11 @@ public class QnAService {
     @Transactional
     public FirstEntryResponseDto updateUserFirstEntry(Long userId) {
         User user = getUserById(userId);
-        if (user.isFirstEntry()) {
-            user.updateIsFirstEntry();
+        if (!user.isFirstEntry()) {
+            return FirstEntryResponseDto.of(false);
         }
-        return FirstEntryResponseDto.of(user);
+        user.updateIsFirstEntry();
+        return FirstEntryResponseDto.of(true);
     }
 
     @Transactional

--- a/umbba-api/src/main/java/sopt/org/umbba/api/service/qna/QnAService.java
+++ b/umbba-api/src/main/java/sopt/org/umbba/api/service/qna/QnAService.java
@@ -66,7 +66,10 @@ public class QnAService {
         log.info("matchUser: {} -> parentchildDao.findMatchUserByUserId()의 결과", matchUser);
 
         // 유저의 상태에 따른 분기처리
-        if (matchUser.isEmpty()) {
+        if (!checkFirstAnswerCompleted(userId)) {
+            return firstTutorialQnA();
+        }
+        else if (matchUser.isEmpty()) {
             return invitation(userId);
         }
         else if (matchUser.get().getUsername() == null) {
@@ -77,6 +80,17 @@ public class QnAService {
         }
 
         return GetInvitationResponseDto.of();
+    }
+    private boolean checkFirstAnswerCompleted(Long userId) {
+        User user = getUserById(userId);
+        QnA firstQnA = user.getParentChild().getQnaList().get(0);
+
+        if (user.isMeChild() && firstQnA.isChildAnswer()) {
+            return true;
+        } else if (!user.isMeChild() && firstQnA.isParentAnswer()) {
+            return true;
+        }
+        return false;
     }
 
     @Transactional
@@ -445,6 +459,10 @@ public class QnAService {
 
     private GetInvitationResponseDto withdrawUser() {
         return GetInvitationResponseDto.of(false);
+    }
+
+    private GetInvitationResponseDto firstTutorialQnA() {
+        return GetInvitationResponseDto.ofFirst(false);
     }
 
 

--- a/umbba-api/src/main/java/sopt/org/umbba/api/service/user/AuthService.java
+++ b/umbba-api/src/main/java/sopt/org/umbba/api/service/user/AuthService.java
@@ -56,6 +56,7 @@ public class AuthService {
                     .isMeChild(true)
                     .isMatchFinish(false)
                     .fcmToken(request.getFcmToken())
+                    .isFirstEntry(true)
                     .build();
 
             userRepository.save(user);

--- a/umbba-common/src/main/java/sopt/org/umbba/common/exception/SuccessType.java
+++ b/umbba-common/src/main/java/sopt/org/umbba/common/exception/SuccessType.java
@@ -28,7 +28,7 @@ public enum SuccessType {
     GET_MY_USER_INFO_SUCCESS(HttpStatus.OK, "마이페이지 내 정보 조회에 성공했습니다."),
     TEST_SUCCESS(HttpStatus.OK, "데모데이 테스트용 API 호출에 성공했습니다."),
     RESTART_QNA_SUCCESS(HttpStatus.OK, "7일 이후 문답이 정상적으로 시작되었습니다."),
-    GET_USER_FIRST_ENTRY_SUCCESS(HttpStatus.OK, "7일 이후 문답이 정상적으로 시작되었습니다."),
+    GET_USER_FIRST_ENTRY_SUCCESS(HttpStatus.OK, "유저의 첫 진입여부 조회에 성공했습니다."),
 
 
     /**

--- a/umbba-common/src/main/java/sopt/org/umbba/common/exception/SuccessType.java
+++ b/umbba-common/src/main/java/sopt/org/umbba/common/exception/SuccessType.java
@@ -28,6 +28,7 @@ public enum SuccessType {
     GET_MY_USER_INFO_SUCCESS(HttpStatus.OK, "마이페이지 내 정보 조회에 성공했습니다."),
     TEST_SUCCESS(HttpStatus.OK, "데모데이 테스트용 API 호출에 성공했습니다."),
     RESTART_QNA_SUCCESS(HttpStatus.OK, "7일 이후 문답이 정상적으로 시작되었습니다."),
+    GET_USER_FIRST_ENTRY_SUCCESS(HttpStatus.OK, "7일 이후 문답이 정상적으로 시작되었습니다."),
 
 
     /**

--- a/umbba-domain/src/main/java/sopt/org/umbba/domain/domain/user/User.java
+++ b/umbba-domain/src/main/java/sopt/org/umbba/domain/domain/user/User.java
@@ -1,14 +1,31 @@
 package sopt.org.umbba.domain.domain.user;
 
-import lombok.*;
-import lombok.extern.slf4j.Slf4j;
+import java.util.List;
+
+import javax.persistence.Column;
+import javax.persistence.ConstraintMode;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.ForeignKey;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import sopt.org.umbba.domain.domain.common.AuditingTimeEntity;
 import sopt.org.umbba.domain.domain.parentchild.Parentchild;
-
-import javax.persistence.*;
-import java.util.List;
 
 @Slf4j
 @Entity

--- a/umbba-domain/src/main/java/sopt/org/umbba/domain/domain/user/User.java
+++ b/umbba-domain/src/main/java/sopt/org/umbba/domain/domain/user/User.java
@@ -89,6 +89,8 @@ public class User extends AuditingTimeEntity {
 
     private boolean deleted = Boolean.FALSE;
 
+    private boolean isFirstEntry = Boolean.TRUE;
+
     // 로그인 새롭게 할 때마다 해당 필드들 업데이트
     public void updateSocialInfo(String socialNickname, String socialProfileImage, String socialAccessToken/*, String socialRefreshToken*/) {
         this.socialNickname = socialNickname;
@@ -101,6 +103,10 @@ public class User extends AuditingTimeEntity {
         this.username = name;
         this.gender = gender;
         this.bornYear = bornYear;
+    }
+
+    public void updateIsFirstEntry() {
+        this.isFirstEntry = false;
     }
 
     public void deleteSocialInfo() {


### PR DESCRIPTION
<!-- - 
❗️ PR 제목은 아래의 형식을 맞춰주세요 
- [FEAT] : 기능 추가
- [FIX] : 에러 수정, 버그 수정
- [CHORE] : gradle 세팅, 위의 것 이외에 거의 모든 것
- [DOCS] : README, 문서
- [REFACTOR] : 코드 리펙토링 (기능 변경 없이 코드만 수정할 때)
- [MODIFY] : 코드 수정 (기능의 변화가 있을 때)
-->

## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
closed #125 

## ✨ 어떤 이유로 변경된 내용인지
<!-- 어떤 기능을 만들기 위한 내용인지 적어주세요 -->
<!-- 그게 아닌 경우에는 어떤 문제를 해결하기 위한 것인지 적어주세요 -->
1. 튜토리얼 화면을 띄우기 위한 유저의 **`홈 화면 첫 진입 여부`** 구분
    
    → 기존에 메인페이지 API 호출했던 부분 전에 **유저의 첫 진입 여부 조회 API를 먼저 호출**하여 튜토리얼을 띄울지에 대한 판단을 수행한다. 
    
    - ❗ **`is_first_entry`** = true 인 경우애 튜토리얼 진행  *나머지는 모두 false

    
2. 홈 화면 Case `response_case` 추가    
    → 3가지의 response_case로 응답 값을 구분했던 API 에서 4번 케이스와 유저의 첫 질문 답변 작성 여부에 대한 필드가 추가되어, **`response_case = 4`**, **`is_user_first_answer = false`** 인 경우에 따라 첫 질문 답변 작성을 유도한다. 
    

## 🙏 검토 혹은 리뷰어에게 남기고 싶은 말
- 클라&모두에게 공유 : https://www.notion.so/SP3-API-a1bdc3cea2bd4aa4a009490982ecdafc?pvs=4#64a6ed7ea8b34ac4b70b66f6c6b06ed6

- 서버 내부 로직에 대한 공유 : https://www.notion.so/daee7f35dcfb46bf9447277959ddf019?pvs=4

위 링크에 클라이언트의 동작과 내부 구현에 대한 상세한 내용을 적어두었으니 참고해 주시기 바랍니다 :)

- 테스트는 완료했고, 추가로 고려하면 좋을 것 같은 내용이 있다면 자유롭게 의견 주세요 !!