### PR TITLE
[FIX] 튜토리얼 오늘의 질문 알 수 있도록 변경

### DIFF
--- a/umbba-api/src/main/java/sopt/org/umbba/api/controller/qna/dto/response/TodayQnAResponseDto.java
+++ b/umbba-api/src/main/java/sopt/org/umbba/api/controller/qna/dto/response/TodayQnAResponseDto.java
@@ -54,20 +54,37 @@ public class TodayQnAResponseDto {
             isMyAnswer = todayQnA.isParentAnswer();
         }
 
-        return TodayQnAResponseDto.builder()
-                .qnaId(todayQnA.getId())
-                .index(count)
-                .section(todayQuestion.getSection().getValue())
-                .topic(todayQuestion.getTopic())
-                .opponentQuestion(opponentQuestion)
-                .myQuestion(myQuestion)
-                .opponentAnswer(opponentAnswer)
-                .myAnswer(myAnswer)
-                .isOpponentAnswer(isOpponentAnswer)
-                .isMyAnswer(isMyAnswer)
-                .opponentUsername(opponentUser.getUsername())
-                .myUsername(myUser.getUsername())
-                .build();
+        if (opponentUser != null) {
+            return TodayQnAResponseDto.builder()
+                    .qnaId(todayQnA.getId())
+                    .index(count)
+                    .section(todayQuestion.getSection().getValue())
+                    .topic(todayQuestion.getTopic())
+                    .opponentQuestion(opponentQuestion)
+                    .myQuestion(myQuestion)
+                    .opponentAnswer(opponentAnswer)
+                    .myAnswer(myAnswer)
+                    .isOpponentAnswer(isOpponentAnswer)
+                    .isMyAnswer(isMyAnswer)
+                    .opponentUsername(opponentUser.getUsername())
+                    .myUsername(myUser.getUsername())
+                    .build();
+        } else {
+            return TodayQnAResponseDto.builder()
+                    .qnaId(todayQnA.getId())
+                    .index(count)
+                    .section(todayQuestion.getSection().getValue())
+                    .topic(todayQuestion.getTopic())
+                    .opponentQuestion(null)
+                    .myQuestion(myQuestion)
+                    .opponentAnswer(null)
+                    .myAnswer(myAnswer)
+                    .isOpponentAnswer(null)
+                    .isMyAnswer(isMyAnswer)
+                    .opponentUsername(null)
+                    .myUsername(myUser.getUsername())
+                    .build();
+        }
     }
 }
 

--- a/umbba-api/src/main/java/sopt/org/umbba/api/service/qna/QnAService.java
+++ b/umbba-api/src/main/java/sopt/org/umbba/api/service/qna/QnAService.java
@@ -55,9 +55,18 @@ public class QnAService {
         Parentchild parentchild = getParentchildByUser(myUser);
         QnA todayQnA = getTodayQnAByParentchild(parentchild);
         Question todayQuestion = todayQnA.getQuestion();
-        User opponentUser = getOpponentByParentchild(parentchild, userId);
 
-        return TodayQnAResponseDto.of(myUser, opponentUser, parentchild.getCount(), todayQnA, todayQuestion);
+        User opponentUser;
+        List<User> opponentUserList = userRepository.findUserByParentChild(parentchild)
+                .stream()
+                .filter(user -> !user.getId().equals(userId))
+                .collect(Collectors.toList());
+        if (opponentUserList.isEmpty()) {
+            return TodayQnAResponseDto.of(myUser, null, parentchild.getCount(), todayQnA, todayQuestion);
+        } else {
+            opponentUser = opponentUserList.get(0);
+            return TodayQnAResponseDto.of(myUser, opponentUser, parentchild.getCount(), todayQnA, todayQuestion);
+        }
     }
 
     public GetInvitationResponseDto getInvitation(Long userId) {


### PR DESCRIPTION
## 📌 관련 이슈
closed #130 

## ✨ 어떤 이유로 변경된 내용인지
- SP3 변경사항으로 인해 부모 자식 관계에 1명만 참여하고 있을 때도 오늘의 질문을 알 수 있습니다! (튜토리얼용 첫번째 질문)
- 정확히는 GET /home/case를 호출했을 때 response_case=4인 경우, 튜토리얼과 함께 GET /qna/today 호출이 가능해야 합니다.
   
  (아래 뷰가 나오는 상황)
  <img src=https://github.com/Team-Umbba/Umbba-Server/assets/67463603/a6dac48d-0e77-48a4-86d3-95784482cf62 width=30%>

- 따라서 기존에 GET /qna/today 호출 시 매칭이 완료되지 않았을 경우 에러 핸들링 했던 것을 수정했습니다.

## 🙏 검토 혹은 리뷰어에게 남기고 싶은 말

### 테스트 결과

  <img width="60%" alt="image" src="https://github.com/Team-Umbba/Umbba-Server/assets/67463603/d6157ac9-80f3-4fd5-bda3-d34f20aeb286">

### 명세서 반영

  <img width="515" alt="image" src="https://github.com/Team-Umbba/Umbba-Server/assets/67463603/e858b496-0bcf-4e5b-ada5-13cb20d0f690">
