### PR TITLE
[FIX] 엔딩 페이지 한쪽에서만 뜨는 오류 수정

### DIFF
--- a/umbba-domain/src/main/java/sopt/org/umbba/domain/domain/user/User.java
+++ b/umbba-domain/src/main/java/sopt/org/umbba/domain/domain/user/User.java
@@ -108,6 +108,8 @@ public class User extends AuditingTimeEntity {
 
     private boolean isFirstEntry = Boolean.TRUE;
 
+    private boolean isEndingDone = Boolean.FALSE;
+
     // 로그인 새롭게 할 때마다 해당 필드들 업데이트
     public void updateSocialInfo(String socialNickname, String socialProfileImage, String socialAccessToken/*, String socialRefreshToken*/) {
         this.socialNickname = socialNickname;
@@ -125,6 +127,8 @@ public class User extends AuditingTimeEntity {
     public void updateIsFirstEntry() {
         this.isFirstEntry = false;
     }
+
+    public void updateIsEndingDone() { this.isEndingDone = true; }
 
     public void deleteSocialInfo() {
         this.socialPlatform = SocialPlatform.WITHDRAW;


### PR DESCRIPTION
## 📌 관련 이슈
closed #132

## ✨ 어떤 이유로 변경된 내용인지
- 현재 한쪽에서 엔딩페이지를 확인한 경우, 다른 측에서 엔딩페이지가 뜨지 않는 오류가 있습니다!
- 이는 현재 답변이 7일차인지 + 둘다 답변을 완료했는지 여부로 판단하고 있기 때문인데요,
- 이 오류를 해결하기 위해 DB에 필드가 추가되어야 함을 파악했습니다.
- 따라서 DB 필드 추가 + 엔딩 페이지 로직 변경이 이루어져야 합니다!

## 🙏 검토 혹은 리뷰어에게 남기고 싶은 말
