### PR TITLE
[FEAT] Album  API 추가 기능 구현

### DIFF
--- a/umbba-api/src/main/java/sopt/org/umbba/api/controller/album/AlbumController.java
+++ b/umbba-api/src/main/java/sopt/org/umbba/api/controller/album/AlbumController.java
@@ -1,6 +1,7 @@
 package sopt.org.umbba.api.controller.album;
 
 import static sopt.org.umbba.api.config.jwt.JwtProvider.*;
+import static sopt.org.umbba.api.service.album.AlbumService.*;
 import static sopt.org.umbba.common.exception.SuccessType.*;
 import static sopt.org.umbba.external.s3.S3BucketPrefix.*;
 
@@ -60,7 +61,9 @@ public class AlbumController {
 	@ResponseStatus(HttpStatus.OK)
 	public ApiResponse deleteAlbum(@PathVariable final Long albumId, final Principal principal) {
 		String imgUrl = albumService.deleteAlbum(albumId, getUserFromPrincial(principal));
-		s3Service.deleteS3Image(imgUrl);
+		if (!imgUrl.equals(ALBUM_EXAMPLE)) {   // Example Album의 이미지는 삭제하지 X
+			s3Service.deleteS3Image(imgUrl);
+		}
 		return ApiResponse.success(DELETE_ALBUM_SUCCESS);
 	}
 

--- a/umbba-api/src/main/java/sopt/org/umbba/api/service/album/AlbumService.java
+++ b/umbba-api/src/main/java/sopt/org/umbba/api/service/album/AlbumService.java
@@ -35,6 +35,11 @@ public class AlbumService {
 			throw new CustomException(ErrorType.MAX_LIMIT_ALBUM_UPLOAD);
 		}
 
+		// 앨범을 처음 등록하는 경우
+		if (parentchild.getAlbumList().isEmpty() && !parentchild.isFirstAlbumUpload()) {
+			parentchild.updateFirstAlbumUpload();
+		}
+
 		Album album = Album.builder()
 			.title(request.getTitle())
 			.content(request.getContent())
@@ -69,9 +74,24 @@ public class AlbumService {
 		List<Album> albumList = albumRepository.findAllByParentchildOrderByCreatedAtDesc(
 			parentchild);
 
+		// Album을 아직 한번도 등록하지 않은 경우
+		if (albumList.isEmpty() && !parentchild.isFirstAlbumUpload()) {
+			return List.of(AlbumResponseDto.of(createAlbumExample(parentchild)));
+		}
+
 		return albumList.stream()
 			.map(AlbumResponseDto::of)
 			.collect(Collectors.toList());
+	}
+
+	private Album createAlbumExample(Parentchild parentchild) {
+		return Album.builder()
+			.title("사진의 제목을 입력할 수 있어요")
+			.content("사진에 대해 소개해요")
+			.imgUrl("imgUrl")
+			.writer("직성자")
+			.parentchild(parentchild)
+			.build();
 	}
 
 	private User getUserById(Long userId) {  // TODO userId -> Parentchild 한번에 가져오기

--- a/umbba-api/src/main/java/sopt/org/umbba/api/service/album/AlbumService.java
+++ b/umbba-api/src/main/java/sopt/org/umbba/api/service/album/AlbumService.java
@@ -59,6 +59,12 @@ public class AlbumService {
 
 		User user = getUserById(userId);
 		Parentchild parentchild = getParentchildByUser(user);
+
+		// Sample Album을 삭제할 경우
+		if (albumId.equals(0L)) {
+			parentchild.updateDeleteSampleAlbum();
+		}
+
 		Album album = getAlbumById(albumId);
 
 		album.deleteParentchild();
@@ -75,8 +81,8 @@ public class AlbumService {
 			parentchild);
 
 		// Album을 아직 한번도 등록하지 않은 경우
-		if (albumList.isEmpty() && !parentchild.isFirstAlbumUpload()) {
-			return List.of(AlbumResponseDto.of(createAlbumExample(parentchild)));
+		if (albumList.isEmpty() && !parentchild.isFirstAlbumUpload() && !parentchild.isDeleteSampleAlbum()) {
+			return List.of(AlbumResponseDto.of(createAlbumExample()));
 		}
 
 		return albumList.stream()
@@ -84,14 +90,9 @@ public class AlbumService {
 			.collect(Collectors.toList());
 	}
 
-	private Album createAlbumExample(Parentchild parentchild) {
-		return Album.builder()
-			.title("사진의 제목을 입력할 수 있어요")
-			.content("사진에 대해 소개해요")
-			.imgUrl("imgUrl")
-			.writer("직성자")
-			.parentchild(parentchild)
-			.build();
+	private Album createAlbumExample() {
+		return new Album(0L, "사진의 제목을 입력할 수 있어요", "사진에 대해 소개해요",
+			"imgUrl", "직성자");
 	}
 
 	private User getUserById(Long userId) {  // TODO userId -> Parentchild 한번에 가져오기

--- a/umbba-api/src/main/java/sopt/org/umbba/api/service/album/AlbumService.java
+++ b/umbba-api/src/main/java/sopt/org/umbba/api/service/album/AlbumService.java
@@ -31,6 +31,10 @@ public class AlbumService {
 		User user = getUserById(userId);
 		Parentchild parentchild = getParentchildByUser(user);
 
+		if (parentchild.isOverMaxAlbumLimit()) {
+			throw new CustomException(ErrorType.MAX_LIMIT_ALBUM_UPLOAD);
+		}
+
 		Album album = Album.builder()
 			.title(request.getTitle())
 			.content(request.getContent())

--- a/umbba-api/src/main/java/sopt/org/umbba/api/service/album/AlbumService.java
+++ b/umbba-api/src/main/java/sopt/org/umbba/api/service/album/AlbumService.java
@@ -25,6 +25,8 @@ public class AlbumService {
 	private final AlbumRepository albumRepository;
 	private final UserRepository userRepository;
 
+	public static final String ALBUM_EXAMPLE = "example";
+
 	@Transactional
 	public Long createAlbum(final CreateAlbumRequestDto request, final String imgUrl, final Long userId) {
 
@@ -63,6 +65,7 @@ public class AlbumService {
 		// Sample Album을 삭제할 경우
 		if (albumId.equals(0L)) {
 			parentchild.updateDeleteSampleAlbum();
+			return ALBUM_EXAMPLE;
 		}
 
 		Album album = getAlbumById(albumId);

--- a/umbba-common/src/main/java/sopt/org/umbba/common/exception/ErrorType.java
+++ b/umbba-common/src/main/java/sopt/org/umbba/common/exception/ErrorType.java
@@ -105,6 +105,8 @@ public enum ErrorType {
      * 501 NOT_IMPLEMENTED
      */
     NEED_MORE_QUESTION(HttpStatus.NOT_IMPLEMENTED, "남은 질문이 없습니다. 질문을 추가해주세요."),
+    MAX_LIMIT_ALBUM_UPLOAD(HttpStatus.NOT_IMPLEMENTED, "한 부모자식마다 최대 15개의 업로드까지만 허용합니다."),
+
 
     ;
 

--- a/umbba-domain/src/main/java/sopt/org/umbba/domain/domain/album/Album.java
+++ b/umbba-domain/src/main/java/sopt/org/umbba/domain/domain/album/Album.java
@@ -52,6 +52,14 @@ public class Album extends AuditingTimeEntity {
 		this.parentchild = parentchild;
 	}
 
+	public Album(Long id, String title, String content, String imgUrl, String writer) {
+		this.id = id;
+		this.title = title;
+		this.content = content;
+		this.imgUrl = imgUrl;
+		this.writer = writer;
+	}
+
 	public void setParentchild(Parentchild parentchild) {
 		this.parentchild = parentchild;
 

--- a/umbba-domain/src/main/java/sopt/org/umbba/domain/domain/parentchild/Parentchild.java
+++ b/umbba-domain/src/main/java/sopt/org/umbba/domain/domain/parentchild/Parentchild.java
@@ -114,9 +114,15 @@ public class Parentchild extends AuditingTimeEntity {
 
     private boolean isFirstAlbumUpload = false;
 
+    private boolean isDeleteSampleAlbum = false;
+
     public void updateFirstAlbumUpload() {
         this.isFirstAlbumUpload = true;
     }
+    public void updateDeleteSampleAlbum() {
+        this.isDeleteSampleAlbum = true;
+    }
+
 
     public void setQna(QnA qnA) {
         if (qnaList.size() >= 7) {

--- a/umbba-domain/src/main/java/sopt/org/umbba/domain/domain/parentchild/Parentchild.java
+++ b/umbba-domain/src/main/java/sopt/org/umbba/domain/domain/parentchild/Parentchild.java
@@ -112,6 +112,12 @@ public class Parentchild extends AuditingTimeEntity {
 
     private boolean deleted = Boolean.FALSE;
 
+    private boolean isFirstAlbumUpload = false;
+
+    public void updateFirstAlbumUpload() {
+        this.isFirstAlbumUpload = true;
+    }
+
     public void setQna(QnA qnA) {
         if (qnaList.size() >= 7) {
             throw new CustomException(ErrorType.ALREADY_QNA_LIST_FULL);

--- a/umbba-domain/src/main/java/sopt/org/umbba/domain/domain/parentchild/Parentchild.java
+++ b/umbba-domain/src/main/java/sopt/org/umbba/domain/domain/parentchild/Parentchild.java
@@ -136,4 +136,8 @@ public class Parentchild extends AuditingTimeEntity {
         }
     }
 
+    public boolean isOverMaxAlbumLimit() {
+        return getAlbumList().size() >= 15;
+    }
+
 }


### PR DESCRIPTION
<!-- - 
❗️ PR 제목은 아래의 형식을 맞춰주세요 
- [FEAT] : 기능 추가
- [FIX] : 에러 수정, 버그 수정
- [CHORE] : gradle 세팅, 위의 것 이외에 거의 모든 것
- [DOCS] : README, 문서
- [REFACTOR] : 코드 리펙토링 (기능 변경 없이 코드만 수정할 때)
- [MODIFY] : 코드 수정 (기능의 변화가 있을 때)
-->

## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
closed #138 

## ✨ 어떤 이유로 변경된 내용인지
<!-- 어떤 기능을 만들기 위한 내용인지 적어주세요 -->
<!-- 그게 아닌 경우에는 어떤 문제를 해결하기 위한 것인지 적어주세요 -->

#### 최대 업로드 수 제한
Album 추가 등록 시, 최대 허용 가능한 업로드 수를 제한하는 방식으로 변경했습니다.
-> 해당 HTTP Status는 예외처리 편의성을 고려하여 **501 Not Implemented**로 처리했습니다!

#### 튜토리얼용 Example Album 추가
Parentchild 테이블에 `isFirstAlbumUpload` , `isDeleteSampleAlbum`라는 필드를 추가하여 분기처리 하고, 아직 한번도 앨범을 등록하지 않은 경우라면, sample 데이터 (id 0번)를 리스트에 담아서 응답하도록 구현했습니다.


## 🙏 검토 혹은 리뷰어에게 남기고 싶은 말
- 아직 Example 고정 이미지 URL은 추가해두지 않은 상태입니다.
- 기획 측에 여쭤본 상황이고, 답변 받으면 URL까지 반영해서 올리겠습니다!