### PR TITLE
[CHORE] link default img s3 url 

### DIFF
--- a/umbba-api/src/main/java/sopt/org/umbba/api/controller/album/AlbumController.java
+++ b/umbba-api/src/main/java/sopt/org/umbba/api/controller/album/AlbumController.java
@@ -41,6 +41,8 @@ public class AlbumController {
 	private final AlbumService albumService;
 	private final S3Service s3Service;
 
+	private static final String DEFAULT_ALBUM_IMG = "default_img.png";
+
 	@PostMapping
 	@ResponseStatus(HttpStatus.CREATED)
 	public ApiResponse createAlbum(@Valid @RequestBody final CreateAlbumRequestDto request, final Principal principal, HttpServletResponse response) {
@@ -70,6 +72,7 @@ public class AlbumController {
 	@GetMapping
 	@ResponseStatus(HttpStatus.OK)
 	public ApiResponse<List<AlbumResponseDto>> getAlbumList(final Principal principal) {
-		return ApiResponse.success(GET_ALBUM_LIST_SUCCESS, albumService.getAlbumList(getUserFromPrincial(principal)));
+		String defaultImgUrl = s3Service.getS3ImgUrl(ALBUM_PREFIX.getValue(), DEFAULT_ALBUM_IMG);
+		return ApiResponse.success(GET_ALBUM_LIST_SUCCESS, albumService.getAlbumList(defaultImgUrl, getUserFromPrincial(principal)));
 	}
 }

--- a/umbba-api/src/main/java/sopt/org/umbba/api/service/album/AlbumService.java
+++ b/umbba-api/src/main/java/sopt/org/umbba/api/service/album/AlbumService.java
@@ -77,7 +77,7 @@ public class AlbumService {
 		return album.getImgUrl();
 	}
 
-	public List<AlbumResponseDto> getAlbumList(final Long userId) {
+	public List<AlbumResponseDto> getAlbumList(final String defaultImgUrl, final Long userId) {
 		User user = getUserById(userId);
 		Parentchild parentchild = getParentchildByUser(user);
 		List<Album> albumList = albumRepository.findAllByParentchildOrderByCreatedAtDesc(
@@ -85,7 +85,7 @@ public class AlbumService {
 
 		// Album을 아직 한번도 등록하지 않은 경우
 		if (albumList.isEmpty() && !parentchild.isFirstAlbumUpload() && !parentchild.isDeleteSampleAlbum()) {
-			return List.of(AlbumResponseDto.of(createAlbumExample()));
+			return List.of(AlbumResponseDto.of(createAlbumExample(defaultImgUrl)));
 		}
 
 		return albumList.stream()
@@ -93,9 +93,8 @@ public class AlbumService {
 			.collect(Collectors.toList());
 	}
 
-	private Album createAlbumExample() {
-		return new Album(0L, "사진의 제목을 입력할 수 있어요", "사진에 대해 소개해요",
-			"https://i1.sndcdn.com/artworks-l2lCmUXC61XR2HM5-gwB8Vg-t500x500.jpg", "직성자");  // TODO 기획 측에서 전달받은 이미지 url로 변경
+	private Album createAlbumExample(final String defaultImgUrl) {
+		return new Album(0L, "사진의 제목을 입력할 수 있어요", "사진에 대해 소개해요", defaultImgUrl, "직성자");
 	}
 
 	private User getUserById(Long userId) {  // TODO userId -> Parentchild 한번에 가져오기


### PR DESCRIPTION
<!-- - 
❗️ PR 제목은 아래의 형식을 맞춰주세요 
- [FEAT] : 기능 추가
- [FIX] : 에러 수정, 버그 수정
- [CHORE] : gradle 세팅, 위의 것 이외에 거의 모든 것
- [DOCS] : README, 문서
- [REFACTOR] : 코드 리펙토링 (기능 변경 없이 코드만 수정할 때)
- [MODIFY] : 코드 수정 (기능의 변화가 있을 때)
-->

## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
closed #151 

## ✨ 어떤 이유로 변경된 내용인지
<!-- 어떤 기능을 만들기 위한 내용인지 적어주세요 -->
<!-- 그게 아닌 경우에는 어떤 문제를 해결하기 위한 것인지 적어주세요 -->

- 기록하기 앨범 목록 조회 API에서 빈 리스트인 경우, 샘플 이미지 링크가 하드코딩 되어 있던 부분을 수정했습니다
   - Controller 단에서 s3Service를 이용해 default img의 url을 받아오도록 param 변경 (보안상의 문제)
   - s3 버킷에 default img 업로드 (추후 다른 이미지로 교체 가능하도록)

## 🙏 검토 혹은 리뷰어에게 남기고 싶은 말
